### PR TITLE
feat: add changepoint process generators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/docs/Guide CPD Benchmark.md
+++ b/docs/Guide CPD Benchmark.md
@@ -38,7 +38,7 @@ Set-Location pysatl-cpd
 
 ### Available distributions
 
-| Распределение       | Название              | Параметры                                               |
+| Distribution        | Name                  | Parameters                                              |
 | ------------------- | --------------------- | ------------------------------------------------------- |
 | Normal              | `normal`              | `mean`, `variance`                                      |
 | Exponential         | `exponential`         | `rate`                                                  |
@@ -47,7 +47,7 @@ Set-Location pysatl-cpd
 | Beta                | `beta`                | `alpha`, `beta`                                         |
 | Gamma               | `gamma`               | `alpha`, `beta`                                         |
 | t-Student           | `t`                   | `n`                                                     |
-| Lognormal           | `lognorm`             | `s`                                                     |
+| Lognormal           | `lognorm`             | `mean`, `shape`                                         |
 | Multivariate normal | `multivariate_normal` | `mean`, in the form of string of list, z `"[0.5, 2.0]"` |
 
 

--- a/pysatl_cpd/generator/__init__.py
+++ b/pysatl_cpd/generator/__init__.py
@@ -6,7 +6,7 @@ __author__ = "Loikov Vladislav"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
-
+from pysatl_cpd.generator.changepoint_process import ChangepointProcess, PoissonChangepointProcess
 from pysatl_cpd.generator.config_parser import (
     ConfigParser,
 )
@@ -38,6 +38,7 @@ from pysatl_cpd.generator.saver import (
 
 __all__ = [
     "BetaDistribution",
+    "ChangepointProcess",
     "ConfigParser",
     "DatasetDescriptionBuilder",
     "DatasetGenerator",
@@ -50,6 +51,7 @@ __all__ = [
     "LogNormDistribution",
     "MultivariateNormalDistribution",
     "NormalDistribution",
+    "PoissonChangepointProcess",
     "SampleDescription",
     "ScipyDatasetGenerator",
     "TDistribution",

--- a/pysatl_cpd/generator/changepoint_process.py
+++ b/pysatl_cpd/generator/changepoint_process.py
@@ -1,0 +1,71 @@
+from abc import ABC, abstractmethod
+from typing import Callable
+
+import scipy.stats as sc
+
+from pysatl_cpd.generator.distributions import (
+    Distribution,
+)
+
+
+class ChangepointProcess(ABC):
+    """
+    Abstract class for processes that generate change points (via segment lengths).
+    """
+
+    @abstractmethod
+    def generate_segments(self) -> tuple[list[Distribution], list[int]]:
+        """
+        Generates a list of distributions and their corresponding segment lengths.
+
+        :return: A tuple of a list of distributions and a list of lengths.
+        """
+        raise NotImplementedError
+
+
+class PoissonChangepointProcess(ChangepointProcess):
+    def __init__(
+        self,
+        total_length: int,
+        cp_intensity: float,
+        mean_sampler: Distribution,
+        distribution_factory: Callable[[float], Distribution],
+    ):
+        """
+        :param total_length: The total desired length of the final dataset.
+        :param avg_segment_length: Average expected segment length (parameter `lambda` for Poisson).
+        :param mean_sampler: The distribution from which the average values for each segment will be generated
+        :param distribution_factory: Factory function that generates a Distribution object
+                                    for each segment based on the means returned by mean_sampler
+        """
+        if total_length <= 0 or cp_intensity <= 0:
+            raise ValueError("Length and intensity must be positive")
+
+        self._total_length = total_length
+        self._avg_segment_length = 1.0 / cp_intensity
+        self._mean_sampler = mean_sampler
+        self._distribution_factory = distribution_factory
+
+    def generate_segments(self) -> tuple[list[Distribution], list[int]]:
+        distributions: list[Distribution] = []
+        lengths: list[int] = []
+
+        exp_dist = sc.expon(scale=self._avg_segment_length)
+
+        current_length = 0
+        while current_length < self._total_length:
+            segment_len = int(round(exp_dist.rvs(1)[0]))
+
+            if current_length + segment_len > self._total_length:
+                segment_len = self._total_length - current_length
+
+            lengths.append(segment_len)
+
+            mean_for_segment = self._mean_sampler.scipy_sample(1)[0]
+
+            dist_for_segment = self._distribution_factory(mean_for_segment)
+            distributions.append(dist_for_segment)
+
+            current_length += segment_len
+
+        return distributions, lengths

--- a/pysatl_cpd/generator/changepoint_process.py
+++ b/pysatl_cpd/generator/changepoint_process.py
@@ -6,10 +6,10 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from abc import ABC, abstractmethod
 from typing import Callable
-import numpy as np
 
-from numpy.random import Generator
+import numpy as np
 import scipy.stats as sc
+from numpy.random import Generator
 
 from pysatl_cpd.generator.distributions import (
     Distribution,
@@ -71,7 +71,7 @@ class PoissonChangepointProcess(ChangepointProcess):
         cp_intensity_per_point: float,
         mean_sampler: Distribution,
         distribution_factory: Callable[[float], Distribution],
-        random_state: int = 42
+        random_state: int = 42,
     ):
         """Initializes the PoissonChangepointProcess.
 
@@ -95,7 +95,6 @@ class PoissonChangepointProcess(ChangepointProcess):
 
         current_length = 0
         while current_length < self._total_length:
-
             remaining_length = self._total_length - current_length
             proposed_len = max(1, round(exp_dist.rvs(1, random_state=self.rng)[0]))
             segment_len = min(proposed_len, remaining_length)

--- a/pysatl_cpd/generator/changepoint_process.py
+++ b/pysatl_cpd/generator/changepoint_process.py
@@ -54,7 +54,7 @@ class PoissonChangepointProcess(ChangepointProcess):
 
         current_length = 0
         while current_length < self._total_length:
-            segment_len = int(round(exp_dist.rvs(1)[0]))
+            segment_len = round(exp_dist.rvs(1)[0])
 
             if current_length + segment_len > self._total_length:
                 segment_len = self._total_length - current_length

--- a/pysatl_cpd/generator/distributions.py
+++ b/pysatl_cpd/generator/distributions.py
@@ -9,7 +9,7 @@ __license__ = "SPDX-License-Identifier: MIT"
 import ast
 import math
 from enum import Enum
-from typing import Final, Protocol
+from typing import Final, Protocol, runtime_checkable
 
 import numpy as np
 import scipy.stats as ss
@@ -31,6 +31,7 @@ class Distributions(Enum):
         return self.value
 
 
+@runtime_checkable
 class Distribution(Protocol):
     """
     An interface for all distributions.

--- a/pysatl_cpd/generator/distributions.py
+++ b/pysatl_cpd/generator/distributions.py
@@ -386,14 +386,17 @@ class LogNormDistribution(Distribution):
     Description of log normal distributionn with one parameter
     """
 
-    S_KEY: Final[str] = "s"
+    MU_KEY: Final[str] = "mu"
+    SIGMA_KEY: Final[str] = "sigma"
 
-    s: float
+    mu: float
+    sigma: float
 
-    def __init__(self, s_value: float) -> None:
-        if s_value <= 0:
-            raise ValueError("S parameter must be positive number")
-        self.s = s_value
+    def __init__(self, mu: float, sigma: float):
+        if sigma <= 0:
+            raise ValueError("Sigma parameter must be a positive number")
+        self.mu = mu
+        self.sigma = sigma
 
     @property
     def name(self) -> str:
@@ -402,19 +405,24 @@ class LogNormDistribution(Distribution):
     @property
     def params(self) -> dict[str, str]:
         return {
-            LogNormDistribution.S_KEY: str(self.s),
+            self.MU_KEY: str(self.mu),
+            self.SIGMA_KEY: str(self.sigma),
         }
 
     def scipy_sample(self, length: int) -> npt.NDArray[np.float64]:
-        return ss.lognorm(s=self.s).rvs(size=length)
+        return ss.lognorm(s=self.sigma, scale=np.exp(self.mu)).rvs(size=length)
 
     @classmethod
     def from_params(cls, params: dict[str, str]) -> "LogNormDistribution":
-        num_params = 1
+        num_params = 2
+
         if len(params) != num_params:
-            raise ValueError(f"Log normal distribution must have 1 parameter: {LogNormDistribution.S_KEY}")
-        s = float(params[LogNormDistribution.S_KEY])
-        return cls(s)
+            raise ValueError(f"Log normal distribution must have 2 parameters: '{cls.MU_KEY}', '{cls.SIGMA_KEY}'")
+
+        mu = float(params[cls.MU_KEY])
+        sigma = float(params[cls.SIGMA_KEY])
+
+        return cls(mu, sigma)
 
 
 class MultivariateNormalDistribution(Distribution):

--- a/tests/test_configs/test_config_1.yml
+++ b/tests/test_configs/test_config_1.yml
@@ -50,7 +50,8 @@
     - type: lognorm
       length: 20
       parameters:
-        s: 1
+        mu: 0.0
+        sigma: 1.0
 - name: 20-multivariate_normal-0-1-no-change-point
   distributions:
     - type: multivariate_normal

--- a/tests/test_generator/test_changepoint_process.py
+++ b/tests/test_generator/test_changepoint_process.py
@@ -1,0 +1,125 @@
+import hypothesis.strategies as st
+import numpy as np
+import numpy.typing as npt
+import pytest
+from hypothesis import given
+
+from pysatl_cpd.generator.changepoint_process import PoissonChangepointProcess
+from pysatl_cpd.generator.distributions import Distribution
+
+
+class MockDistribution(Distribution):
+    def __init__(self, mean) -> None:
+        self._mean = mean
+
+    def scipy_sample(self, length: int) -> npt.NDArray[np.float64]:
+        return np.array([self._mean] * length)
+
+    @property
+    def name(self) -> str:
+        return super().name
+
+    @property
+    def params(self) -> dict[str, str]:
+        return super().params
+
+    @classmethod
+    def from_params(cls, params: dict[str, str]) -> "Distribution":
+        raise NotImplementedError
+
+
+def mock_distribution_factory(mean):
+    return MockDistribution(mean)
+
+
+class TestPoissonChangepointProcess:
+    def test_initialization_success(self):
+        total_length = 1000
+        mean_sampler = MockDistribution(mean=10.0)
+        process = PoissonChangepointProcess(
+            total_length=total_length,
+            cp_intensity_per_point=0.01,
+            mean_sampler=mean_sampler,
+            distribution_factory=mock_distribution_factory,
+        )
+        assert process._total_length == total_length
+        assert process._avg_segment_length == pytest.approx(100.0)
+        assert process._mean_sampler is mean_sampler
+        assert process._distribution_factory is mock_distribution_factory
+
+    @pytest.mark.parametrize(
+        "length, intensity",
+        [
+            (0, 0.1),
+            (-100, 0.1),
+            (100, 0),
+            (100, -0.1),
+            (0, 0),
+        ],
+    )
+    def test_initialization_raises_value_error(self, length: int, intensity: float):
+        with pytest.raises(ValueError):
+            PoissonChangepointProcess(
+                total_length=length,
+                cp_intensity_per_point=intensity,
+                mean_sampler=MockDistribution(mean=0),
+                distribution_factory=mock_distribution_factory,
+            )
+
+    def test_generate_segments_output_structure(self):
+        process = PoissonChangepointProcess(
+            total_length=500,
+            cp_intensity_per_point=0.1,
+            mean_sampler=MockDistribution(mean=5.0),
+            distribution_factory=mock_distribution_factory,
+        )
+        distributions, lengths = process.generate_segments()
+
+        assert isinstance(distributions, list)
+        assert isinstance(lengths, list)
+        assert len(distributions) == len(lengths)
+        assert all(isinstance(d, MockDistribution) for d in distributions)
+        assert all(isinstance(length, int) for length in lengths)
+
+    def test_distribution_creation_logic(self):
+        fixed_mean = 42.0
+        mean_sampler = MockDistribution(mean=fixed_mean)
+        process = PoissonChangepointProcess(
+            total_length=100,
+            cp_intensity_per_point=0.2,
+            mean_sampler=mean_sampler,
+            distribution_factory=mock_distribution_factory,
+        )
+        distributions, _ = process.generate_segments()
+
+        assert len(distributions) > 0
+        for dist in distributions:
+            assert isinstance(dist, MockDistribution)
+            assert dist._mean == fixed_mean
+
+    @given(
+        total_length=st.integers(min_value=1, max_value=5000),
+        cp_intensity=st.floats(min_value=0.001, max_value=1.0),
+        mean_value=st.floats(min_value=-1e5, max_value=1e5),
+    )
+    def test_generate_segments_properties_with_hypothesis(
+        self, total_length: int, cp_intensity: float, mean_value: float
+    ):
+        mean_sampler = MockDistribution(mean=mean_value)
+        process = PoissonChangepointProcess(
+            total_length=total_length,
+            cp_intensity_per_point=cp_intensity,
+            mean_sampler=mean_sampler,
+            distribution_factory=mock_distribution_factory,
+        )
+
+        distributions, lengths = process.generate_segments()
+
+        assert sum(lengths) == total_length
+        assert len(distributions) == len(lengths)
+        assert all(isinstance(length, int) for length in lengths)
+        assert all(length >= 0 for length in lengths)
+
+        for dist in distributions:
+            assert isinstance(dist, MockDistribution)
+            assert dist._mean == mean_value

--- a/tests/test_generator/test_changepoint_process.py
+++ b/tests/test_generator/test_changepoint_process.py
@@ -2,63 +2,93 @@ import hypothesis.strategies as st
 import numpy as np
 import numpy.typing as npt
 import pytest
-from hypothesis import given
+import scipy.stats as sc
+from hypothesis import given, settings
+from numpy.random import Generator
 
-from pysatl_cpd.generator.changepoint_process import PoissonChangepointProcess
-from pysatl_cpd.generator.distributions import Distribution
+from pysatl_cpd.generator import Distribution, NormalDistribution, PoissonChangepointProcess, ScipyDatasetGenerator
 
 
 class MockDistribution(Distribution):
-    def __init__(self, mean) -> None:
+    """A mock Distribution for testing purposes."""
+
+    def __init__(self, mean: float) -> None:
         self._mean = mean
 
     def scipy_sample(self, length: int) -> npt.NDArray[np.float64]:
-        return np.array([self._mean] * length)
+        """Returns a simple array of the mean value."""
+
+        return np.full(length, self._mean, dtype=np.float64)
 
     @property
     def name(self) -> str:
-        return super().name
+        return "mock"
 
     @property
     def params(self) -> dict[str, str]:
-        return super().params
+        return {"mean": str(self._mean)}
 
     @classmethod
     def from_params(cls, params: dict[str, str]) -> "Distribution":
+        """Mock does not support instantiation from params."""
+
         raise NotImplementedError
 
 
-def mock_distribution_factory(mean):
+def mock_distribution_factory(mean: float) -> Distribution:
+    """A factory function that returns a MockDistribution instance."""
+
     return MockDistribution(mean)
 
 
 class TestPoissonChangepointProcess:
+    """
+    Tests for the PoissonChangepointProcess class.
+    """
+
     def test_initialization_success(self):
+        """
+        Tests successful initialization of PoissonChangepointProcess
+        and verifies that attributes are set correctly.
+        """
+
         total_length = 1000
-        mean_sampler = MockDistribution(mean=10.0)
+        cp_intensity = 0.01
+        mean_sampler = MockDistribution(mean=10)
+        random_state = 42
+
         process = PoissonChangepointProcess(
             total_length=total_length,
-            cp_intensity_per_point=0.01,
+            cp_intensity_per_point=cp_intensity,
             mean_sampler=mean_sampler,
             distribution_factory=mock_distribution_factory,
+            random_state=random_state,
         )
+
         assert process._total_length == total_length
-        assert process._avg_segment_length == pytest.approx(100.0)
+        assert process._avg_segment_length == 1.0 / cp_intensity
         assert process._mean_sampler is mean_sampler
         assert process._distribution_factory is mock_distribution_factory
+        assert isinstance(process.rng, Generator)
 
     @pytest.mark.parametrize(
-        "length, intensity",
+        "length, intensity, error_msg",
         [
-            (0, 0.1),
-            (-100, 0.1),
-            (100, 0),
-            (100, -0.1),
-            (0, 0),
+            (-100, 0.1, "Length and intensity must be positive"),
+            (100, -0.1, "Length and intensity must be positive"),
+            (0, 0.1, "Length and intensity must be positive"),
+            (100, 0, "Length and intensity must be positive"),
         ],
     )
-    def test_initialization_raises_value_error(self, length: int, intensity: float):
-        with pytest.raises(ValueError):
+    def test_initialization_raises_value_error_for_non_positive_params(
+        self, length: int, intensity: float, error_msg: str
+    ):
+        """
+        Tests that ValueError is raised for non-positive total_length or
+        cp_intensity_per_point.
+        """
+
+        with pytest.raises(ValueError, match=error_msg):
             PoissonChangepointProcess(
                 total_length=length,
                 cp_intensity_per_point=intensity,
@@ -66,60 +96,131 @@ class TestPoissonChangepointProcess:
                 distribution_factory=mock_distribution_factory,
             )
 
-    def test_generate_segments_output_structure(self):
+    @given(
+        total_length=st.integers(min_value=1, max_value=5000),
+        cp_intensity=st.floats(min_value=0.001, max_value=0.8),
+        random_state=st.integers(min_value=0, max_value=100000),
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_generate_segments_output_properties_with_hypothesis(
+        self, total_length: int, cp_intensity: float, random_state: int
+    ):
+        """
+        Tests the basic output properties of generate_segments using Hypothesis.
+        - The sum of lengths equals total_length.
+        - The number of distributions matches the number of segments.
+        - All lengths are positive.
+        - All returned distributions are of the correct type.
+        """
+
         process = PoissonChangepointProcess(
-            total_length=500,
-            cp_intensity_per_point=0.1,
-            mean_sampler=MockDistribution(mean=5.0),
+            total_length=total_length,
+            cp_intensity_per_point=cp_intensity,
+            mean_sampler=MockDistribution(mean=1.0),
             distribution_factory=mock_distribution_factory,
+            random_state=random_state,
         )
+
         distributions, lengths = process.generate_segments()
 
         assert isinstance(distributions, list)
         assert isinstance(lengths, list)
+        assert all(isinstance(d, Distribution) for d in distributions)
+        assert all(isinstance(length, int) and length > 0 for length in lengths)
         assert len(distributions) == len(lengths)
-        assert all(isinstance(d, MockDistribution) for d in distributions)
-        assert all(isinstance(length, int) for length in lengths)
+        assert sum(lengths) == total_length
 
-    def test_distribution_creation_logic(self):
-        fixed_mean = 42.0
-        mean_sampler = MockDistribution(mean=fixed_mean)
-        process = PoissonChangepointProcess(
-            total_length=100,
-            cp_intensity_per_point=0.2,
-            mean_sampler=mean_sampler,
+    def test_generate_segments_reproducibility(self):
+        """
+        Tests that using the same random_state produces the exact same segments.
+        """
+
+        process1 = PoissonChangepointProcess(
+            total_length=500,
+            cp_intensity_per_point=0.02,
+            mean_sampler=MockDistribution(mean=5),
             distribution_factory=mock_distribution_factory,
+            random_state=123,
         )
-        distributions, _ = process.generate_segments()
+        process2 = PoissonChangepointProcess(
+            total_length=500,
+            cp_intensity_per_point=0.02,
+            mean_sampler=MockDistribution(mean=5),
+            distribution_factory=mock_distribution_factory,
+            random_state=123,
+        )
 
-        assert len(distributions) > 0
-        for dist in distributions:
-            assert isinstance(dist, MockDistribution)
-            assert dist._mean == fixed_mean
+        distributions1, lengths1 = process1.generate_segments()
+        distributions2, lengths2 = process2.generate_segments()
 
-    @given(
-        total_length=st.integers(min_value=1, max_value=5000),
-        cp_intensity=st.floats(min_value=0.001, max_value=1.0),
-        mean_value=st.floats(min_value=-1e5, max_value=1e5),
-    )
-    def test_generate_segments_properties_with_hypothesis(
-        self, total_length: int, cp_intensity: float, mean_value: float
-    ):
-        mean_sampler = MockDistribution(mean=mean_value)
+        assert lengths1 == lengths2
+        means1 = [d.params["mean"] for d in distributions1]
+        means2 = [d.params["mean"] for d in distributions2]
+        assert means1 == means2
+
+    def test_segment_lengths_follow_exponential_distribution_ks_test(self):
+        """
+        Performs a Kolmogorov-Smirnov test to verify that segment lengths
+        are exponentially distributed, which is a key property of a Poisson process.
+        The null hypothesis (H0) is that the segment lengths are drawn from an
+        exponential distribution. A high p-value (> 0.05) means we cannot
+        reject H0.
+        """
+
+        total_length = 50000  # A large sample size for a meaningful statistical test
+        cp_intensity = 0.01  # Average segment length = 1/0.01 = 100
+        avg_segment_length = 1.0 / cp_intensity
+
         process = PoissonChangepointProcess(
             total_length=total_length,
             cp_intensity_per_point=cp_intensity,
-            mean_sampler=mean_sampler,
+            mean_sampler=MockDistribution(mean=0),
             distribution_factory=mock_distribution_factory,
+            random_state=42,
         )
 
+        _, lengths = process.generate_segments()
+
+        # The last segment's length is truncated to fit total_length,
+        # so we exclude it from the statistical test to avoid bias.
+        observed_lengths = lengths[:-1]
+        min_num_of_lengths = 30
+
+        if len(observed_lengths) < min_num_of_lengths:
+            pytest.skip("Not enough segments generated for a reliable K-S test.")
+
+        # H0: The observed lengths are from an exponential distribution.
+        min_p_value = 0.05
+        ks_statistic, p_value = sc.kstest(observed_lengths, "expon", args=(0, avg_segment_length))
+
+        assert p_value > min_p_value
+
+    def test_integration_with_scipy_dataset_generator(self):
+        """
+        Tests that the output of PoissonChangepointProcess works correctly
+        as input for ScipyDatasetGenerator to generate a final sample.
+        This test uses real distributions instead of mocks.
+        """
+
+        total_length = 2000
+        mean_sampler = NormalDistribution(mean=0, var=1.0)
+
+        def normal_distribution_factory(mean: float) -> Distribution:
+            return NormalDistribution(mean=mean, var=abs(mean) + 0.1)
+
+        process = PoissonChangepointProcess(
+            total_length=total_length,
+            cp_intensity_per_point=0.05,
+            mean_sampler=mean_sampler,
+            distribution_factory=normal_distribution_factory,
+            random_state=99,
+        )
         distributions, lengths = process.generate_segments()
 
-        assert sum(lengths) == total_length
-        assert len(distributions) == len(lengths)
-        assert all(isinstance(length, int) for length in lengths)
-        assert all(length >= 0 for length in lengths)
+        scipy_generator = ScipyDatasetGenerator()
 
-        for dist in distributions:
-            assert isinstance(dist, MockDistribution)
-            assert dist._mean == mean_value
+        final_sample = scipy_generator.generate_sample(distributions, lengths)
+
+        assert isinstance(final_sample, np.ndarray)
+        assert final_sample.dtype == np.float64
+        assert len(final_sample) == total_length

--- a/tests/test_generator/test_changepoint_process.py
+++ b/tests/test_generator/test_changepoint_process.py
@@ -1,3 +1,10 @@
+"""Tests for changepoint_process module"""
+
+__author__ = "Danil Totmyanin"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
 import hypothesis.strategies as st
 import numpy as np
 import numpy.typing as npt

--- a/tests/test_generator/test_distributions.py
+++ b/tests/test_generator/test_distributions.py
@@ -59,9 +59,10 @@ class TestDistributions:
             (dstr.Distributions.T, {"n": "1", "x": "5"}, ValueError),
             (dstr.Distributions.T, {"n": "-1"}, ValueError),
             (dstr.Distributions.LOGNORM, {}, ValueError),
-            (dstr.Distributions.LOGNORM, {"S": "1"}, KeyError),
-            (dstr.Distributions.LOGNORM, {"s": "1", "x": "5"}, ValueError),
-            (dstr.Distributions.LOGNORM, {"s": "-1"}, ValueError),
+            (dstr.Distributions.LOGNORM, {"mu": "1"}, ValueError),
+            (dstr.Distributions.LOGNORM, {"mu": "0", "Sigma": "1"}, KeyError),
+            (dstr.Distributions.LOGNORM, {"mu": "0", "sigma": "1", "x": "5"}, ValueError),
+            (dstr.Distributions.LOGNORM, {"mu": "0", "sigma": "-1"}, ValueError),
             (dstr.Distributions.MULTIVARIATIVE_NORMAL, {}, ValueError),
             (
                 dstr.Distributions.MULTIVARIATIVE_NORMAL,
@@ -92,7 +93,7 @@ class TestDistributions:
             (dstr.Distributions.BETA, {"alpha": "1", "beta": "1"}),
             (dstr.Distributions.GAMMA, {"alpha": "1", "beta": "1"}),
             (dstr.Distributions.T, {"n": "1"}),
-            (dstr.Distributions.LOGNORM, {"s": "1"}),
+            (dstr.Distributions.LOGNORM, {"mu": "0", "sigma": "1"}),
             (dstr.Distributions.MULTIVARIATIVE_NORMAL, {"mean": "[0.0, 0.1]"}),
         ],
     )


### PR DESCRIPTION
* Add new abstract class ChangepointProcess which generates a configuration of distributions and segment lengths, for subsequent transfer of this information to the generator.
    - Add implementation of ChangepointProcess: PoissonChangepointProcess. Between the moments of changepoint we take an exponential distribution (i.e. the number of changepoints at the moment of time t is a Poisson process), for each state we generate an average and using it we generate the required distribution for this state.

* Update ruff version in pre-commit