### PR TITLE
ci: minor adjustments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.12", "3.13" ]
+        python-version: ["3.13" ]
     runs-on: ${{ matrix.os }}
 
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,13 +61,13 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: poetry run mypy --config-file=pyproject.toml
+        entry: mypy --config-file=pyproject.toml
         language: system
         types_or: [python, pyi]
         pass_filenames: false
       - id: pydoclint
         name: pydoclint
-        entry: poetry run pydoclint
+        entry: pydoclint
         language: system
         types: [python]
         files: ^pysatl_cpd/


### PR DESCRIPTION
This pull request makes minor adjustments to the CI workflow and pre-commit configuration. The main changes are the removal of Python 3.12 from the test matrix and the simplification of pre-commit hook commands to run tools directly, without using Poetry.

- **CI Workflow Updates:**
  * The GitHub Actions workflow now only tests against Python 3.13, removing Python 3.12 from the matrix. (`.github/workflows/ci.yaml`)

- **Pre-commit Hook Simplification:**
  * The `mypy` and `pydoclint` hooks in `.pre-commit-config.yaml` now invoke the tools directly, instead of prefixing the commands with `poetry run`. (`.pre-commit-config.yaml`)