### PR TITLE
Iraedeus/GitHub pages deploy

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,0 +1,55 @@
+name: Docs Deploy
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies (with docs)
+        run: poetry install --with docs
+
+      - name: Generate API
+        run: poetry run python docs/source/generate_api.py
+
+      - name: Build docs (Sphinx)
+        run: |
+          poetry run sphinx-build -E -a -b html docs/source docs/build/html
+          touch docs/build/html/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs/build/html
+
+      - id: deployment
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Generate API
         run: poetry run python docs/source/generate_api.py
 
+      - name: Generate User Guide
+        run: poetry run python docs/source/generate_user_guide.py
+
       - name: Build docs (Sphinx)
         run: |
           poetry run sphinx-build -E -a -b html docs/source docs/build/html

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -2,7 +2,8 @@ name: Docs Preview
 
 on:
   pull_request:
-    branches: [ main ]
+  push:
+    branches-ignore: [ main ]
 
 permissions:
   contents: read
@@ -29,6 +30,9 @@ jobs:
 
       - name: Generate API
         run: poetry run python docs/source/generate_api.py
+
+      - name: Generate User Guide
+        run: poetry run python docs/source/generate_user_guide.py
 
       - name: Build docs (Sphinx)
         run: |

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -1,0 +1,43 @@
+name: Docs Preview
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies (with docs)
+        run: poetry install --with docs
+
+      - name: Generate API
+        run: poetry run python docs/source/generate_api.py
+
+      - name: Build docs (Sphinx)
+        run: |
+          poetry run sphinx-build -E -a -b html docs/source docs/build/html
+          touch docs/build/html/.nojekyll
+
+      - name: Upload docs preview artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-html-preview
+          path: docs/build/html
+          retention-days: 7

--- a/pysatl_cpd/algorithms/online/bayesian/__init__.py
+++ b/pysatl_cpd/algorithms/online/bayesian/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: ascii -*-
-"""Bayesian online change-point detection algorithms.
+r"""Bayesian online change-point detection algorithms.
 
 This package implements Bayesian online change-point detection (BOCPD) following
 the Adams and MacKay (2007) message-passing framework. It provides an abstract

--- a/pysatl_cpd/algorithms/online/bayesian/component/hazard/__init__.py
+++ b/pysatl_cpd/algorithms/online/bayesian/component/hazard/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: ascii -*-
-"""Hazard models for Bayesian online change-point detection.
+r"""Hazard models for Bayesian online change-point detection.
 
 This subpackage provides hazard (changepoint prior) models used in Bayesian
 online change-point detection. Hazard models define the probability that a

--- a/pysatl_cpd/analysis/visualization/online/plotters/online_cpd_plotter.py
+++ b/pysatl_cpd/analysis/visualization/online/plotters/online_cpd_plotter.py
@@ -53,6 +53,7 @@ class OnlineCpdPlotter[StateT: OnlineAlgorithmState]:
         The detection trace from online algorithm execution.
     layout
         Layout strategy to use. Can be:
+
         - An ILayoutStrategy instance
         - One of: "vertical", "split", "dashboard-lite", "dashboard"
         - None (defaults to "vertical")
@@ -728,6 +729,7 @@ class OnlineCpdPlotter[StateT: OnlineAlgorithmState]:
         ----------
         layout
             Layout strategy to use. Can be:
+
             - An ILayoutStrategy instance
             - One of: "vertical", "split", "dashboard-lite", "dashboard"
 


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate documentation building and deployment, and also makes minor improvements to docstring formatting and docstring parameter lists in the codebase.

**CI/CD for Documentation:**

* Added `.github/workflows/docs-deploy.yaml` to automate building and deploying documentation to GitHub Pages on every push to the `main` branch or on manual trigger. This workflow installs dependencies, generates API and user guide docs, builds the Sphinx documentation, and deploys it to GitHub Pages.
* Added `.github/workflows/docs-preview.yaml` to build documentation previews for pull requests and non-main branch pushes. The workflow builds the documentation and uploads it as an artifact for preview, aiding review and validation before merging.

**Docstring and Documentation Improvements:**

* Changed module-level docstrings in `pysatl_cpd/algorithms/online/bayesian/__init__.py` and `pysatl_cpd/algorithms/online/bayesian/component/hazard/__init__.py` from triple double-quotes to triple raw double-quotes for improved formatting and compatibility with documentation tools. [[1]](diffhunk://#diff-2acd498a4989513d48b266988d123b1e1df22ccd6671825a7ee0a4c51a472667L2-R2) [[2]](diffhunk://#diff-94d861a81355bc1c8e0803f6d1c30092bd4702716039e657e3e8bfed3001b93aL2-R2)
* Improved parameter list formatting in the docstrings for `OnlineCpdPlotter` and its `set_layout` method in `pysatl_cpd/analysis/visualization/online/plotters/online_cpd_plotter.py` by adding a blank line before the parameter list, enhancing readability and Sphinx compatibility. [[1]](diffhunk://#diff-f2d24632f301200b8ab791b4cf834c0c934517f48aab5e2e186e37b9614078f0R56) [[2]](diffhunk://#diff-f2d24632f301200b8ab791b4cf834c0c934517f48aab5e2e186e37b9614078f0R732)