### PR TITLE
Iraedeus/readme fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,15 +67,17 @@ jobs:
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.xml
           format: cobertura
           parallel: true
 
-    coveralls-finish:
-      needs: ci
-      runs-on: ubuntu-latest
-      steps:
-        - name: Close Coveralls build
-          uses: coverallsapp/github-action@v2
-          with:
-            parallel-finished: true
+  coveralls-finish:
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Coveralls build
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,3 +63,9 @@ jobs:
         with:
           name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
           path: coverage.xml
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.xml
+          format: cobertura

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,3 +69,13 @@ jobs:
         with:
           file: coverage.xml
           format: cobertura
+          parallel: true
+
+    coveralls-finish:
+      needs: ci
+      runs-on: ubuntu-latest
+      steps:
+        - name: Close Coveralls build
+          uses: coverallsapp/github-action@v2
+          with:
+            parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PySATL-CPD
 
-[![mypy](https://img.shields.io/github/actions/workflow/status/PySATL/pysatl-cpd-private/.github/workflows/mypy.yaml?label=mypy&style=for-the-badge)](https://github.com/PySATL/pysatl-cpd-private/actions/workflows/mypy.yaml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/PySATL/pysatl-cpd-private/.github/workflows/test.yaml?label=Tests&style=for-the-badge)](https://github.com/PySATL/pysatl-cpd-private/actions/workflows/test.yaml)
-[![Coverage](https://img.shields.io/codecov/c/github/PySATL/pysatl-cpd-private?style=for-the-badge)](https://codecov.io/gh/PySATL/pysatl-cpd-private)
-[![ruff](https://img.shields.io/github/actions/workflow/status/PySATL/pysatl-cpd-private/.github/workflows/ruff.yaml?label=ruff&style=for-the-badge)](https://github.com/PySATL/pysatl-cpd-private/actions/workflows/ruff.yaml)
-[![pydoclint](https://img.shields.io/github/actions/workflow/status/PySATL/pysatl-cpd-private/.github/workflows/pydoclint.yaml?label=pydoclint&style=for-the-badge)](https://github.com/PySATL/pysatl-cpd-private/actions/workflows/pydoclint.yaml)
-[![Docs](https://img.shields.io/github/actions/workflow/status/PySATL/pysatl-cpd-private/.github/workflows/docs.yaml?label=Docs&style=for-the-badge)](https://github.com/PySATL/pysatl-cpd-private/actions/workflows/docs.yaml)
-[![MIT License](https://img.shields.io/github/license/PySATL/pysatl-cpd-private?style=for-the-badge&color=blue)](LICENSE)
+[![mypy](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=mypy&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=Tests&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/PySATL/rework-pysatl-cpd/badge.svg)](https://coveralls.io/github/PySATL/rework-pysatl-cpd)
+[![ruff](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=ruff&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
+[![pydoclint](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=pydoclint&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/docs-deploy.yaml?label=Docs&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/docs-deploy.yaml)
+[![MIT License](https://img.shields.io/github/license/PySATL/rework-pysatl-cpd?style=for-the-badge&color=blue)](LICENSE)
 
 > **Note:** This repository was migrated from a private repository. The commit history has been preserved but does not reflect the actual development timeline.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![mypy](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=mypy&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=Tests&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/PySATL/rework-pysatl-cpd/badge.svg)](https://coveralls.io/github/PySATL/rework-pysatl-cpd)
+[![Coverage](https://img.shields.io/coverallsCoverage/github/PySATL/rework-pysatl-cpd?style=for-the-badge)](https://coveralls.io/github/PySATL/rework-pysatl-cpd)
 [![ruff](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=ruff&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
 [![pydoclint](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/ci.yaml?label=pydoclint&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/ci.yaml)
 [![Docs](https://img.shields.io/github/actions/workflow/status/PySATL/rework-pysatl-cpd/.github/workflows/docs-deploy.yaml?label=Docs&style=for-the-badge)](https://github.com/PySATL/rework-pysatl-cpd/actions/workflows/docs-deploy.yaml)


### PR DESCRIPTION
This pull request updates the project's CI workflow to upload coverage reports to Coveralls and refreshes the badges in the `README.md` to reflect the new repository location and coverage reporting service.

CI/CD and coverage reporting improvements:

* Added a step in `.github/workflows/ci.yaml` to upload code coverage results to Coveralls using the `coverallsapp/github-action`, specifying the `coverage.xml` file in Cobertura format.

Documentation and badge updates:

* Updated all badges in `README.md` to reference the new repository (`rework-pysatl-cpd`) and switched the coverage badge from Codecov to Coveralls, ensuring links and badge sources match the new setup.