### PR TITLE
feat(benchmarking): show progress for parallel registry runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ tqdm = "^4.67.3"
 pyyaml = "^6.0.3"
 ipykernel = "^7.2.0"
 joblib = ">=1.4.0"
+tqdm-joblib = ">=0.0.4"
 arch = ">=7.2.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pysatl_cpd/benchmark/registry.py
+++ b/pysatl_cpd/benchmark/registry.py
@@ -14,6 +14,7 @@ from typing import Generic, TypeVar, cast
 
 from joblib import Parallel, delayed  # type: ignore[import-untyped]
 from tqdm import tqdm
+from tqdm_joblib import tqdm_joblib  # type: ignore[import-untyped]
 
 from pysatl_cpd.core import ChangePointDetector, DetectionTrace
 from pysatl_cpd.core.single_run import SingleRun, SingleRunDescription
@@ -135,9 +136,10 @@ class BenchmarkRegistry(Generic[DataT, TraceT]):
                 )
             return
 
-        results = Parallel(n_jobs=n_jobs, backend=backend)(
-            delayed(_execute_single_run)(detector, key, provider) for key, provider in jobs
-        )
+        with tqdm_joblib(tqdm(total=len(jobs), desc="Benchmarking providers", unit="provider")):
+            results = Parallel(n_jobs=n_jobs, backend=backend)(
+                delayed(_execute_single_run)(detector, key, provider) for key, provider in jobs
+            )
         self._executions_registry.update(dict(results))
 
     def __getitem__(


### PR DESCRIPTION
This pull request adds progress bar support for parallelized benchmarking jobs using `tqdm` and `joblib`. The main improvement is providing real-time feedback to users during long-running benchmarking operations.

**Progress Bar Integration for Parallel Jobs:**

* Added `tqdm-joblib` as a dependency in `pyproject.toml` to enable progress bar support for parallel `joblib` tasks.
* Imported `tqdm_joblib` in `pysatl_cpd/benchmark/registry.py` to facilitate integration with `tqdm`.
* Wrapped the parallel execution of benchmarking jobs in the `update` function with `tqdm_joblib`, displaying a progress bar labeled "Benchmarking providers".