### PR TITLE
fix: tqdm for Parallel Executions

### DIFF
--- a/pysatl_cpd/benchmark/registry.py
+++ b/pysatl_cpd/benchmark/registry.py
@@ -126,19 +126,16 @@ class BenchmarkRegistry(Generic[DataT, TraceT]):
                 continue
             jobs.append((key, provider))
 
-        if n_jobs == 1:
-            for key, provider in tqdm(jobs, desc="Benchmarking providers", unit="provider"):
-                trace: TraceT = cast(TraceT, detector.detect(provider))  # TODO: Runtime check?
-                self._executions_registry[key] = SingleRun(
-                    trace=trace,
-                    provider=provider,
-                )
-            return
-
-        results = Parallel(n_jobs=n_jobs, backend=backend)(
-            delayed(_execute_single_run)(detector, key, provider) for key, provider in jobs
+        parallel = Parallel(
+            n_jobs=n_jobs,
+            backend=backend,
+            return_as="generator",
         )
-        self._executions_registry.update(dict(results))
+
+        results_iter = parallel(delayed(_execute_single_run)(detector, key, provider) for key, provider in jobs)
+
+        for key, run in tqdm(results_iter, total=len(jobs), desc="Benchmarking providers", unit="provider"):
+            self._executions_registry[key] = run
 
     def __getitem__(
         self, key: SingleRunDescription[TimeseriesAnnotation]


### PR DESCRIPTION
## Summary
- Fixed the progress bar behavior in `BenchmarkRegistry.register`: `tqdm` now correctly reports progress not only for `n_jobs=1` but also during parallel execution.
- Switched parallel execution to `Parallel(..., return_as="generator")` so results are consumed incrementally and progress is updated as tasks complete.
- Removed the separate sequential code path: registry updates are now handled through a single unified loop.

## Why
Previously, when `n_jobs > 1`, results were collected only after `Parallel` fully completed, so `tqdm` could not show live progress across providers. The new implementation makes progress reporting consistent across all execution modes.

## Changes
- `pysatl_cpd/benchmark/registry.py`
  - removed the dedicated `n_jobs == 1` block;
  - added `Parallel(..., return_as="generator")`;
  - added iteration over streamed results with `tqdm(..., total=len(jobs))`, saving each result as soon as it arrives.