### PR TITLE
feat: add Symbolic Divergence online change-point detection algorithm

### DIFF
--- a/pysatl_cpd/algorithms/__init__.py
+++ b/pysatl_cpd/algorithms/__init__.py
@@ -74,11 +74,16 @@ CUSUM algorithms:
 
 Symbolic Divergence algorithms:
 
-- ``SymbolicDivergence`` -- Generalized online detector combining a symbol
+- ``SymbolicDivergence`` -- Abstract, generic base detector combining a symbol
   encoder, a divergence, and a change-point statistic.
-- ``SymbolicDivergenceConfiguration`` -- Configuration dataclass for
-  ``SymbolicDivergence``.
-- ``SymbolicDivergenceState`` -- State snapshot for ``SymbolicDivergence``.
+- ``SymbolicDivergenceConfiguration`` -- Base configuration dataclass.
+- ``SymbolicDivergenceState`` -- Base state snapshot.
+- ``SlopeKLSymbolicDivergence`` -- Concrete slope-encoder + KL-divergence
+  detector storing component parameters in its configuration.
+- ``SlopeKLSymbolicDivergenceConfiguration`` -- Configuration for
+  ``SlopeKLSymbolicDivergence``.
+- ``SlopeKLSymbolicDivergenceState`` -- State snapshot for
+  ``SlopeKLSymbolicDivergence``.
 - ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
 - ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
 - ``IDivergence`` -- Protocol for divergence functions.

--- a/pysatl_cpd/algorithms/__init__.py
+++ b/pysatl_cpd/algorithms/__init__.py
@@ -72,6 +72,22 @@ CUSUM algorithms:
   ``AutoregressiveCUSUM``.
 - ``AutoregressiveCusumState`` -- State snapshot for ``AutoregressiveCUSUM``.
 
+Symbolic Divergence algorithms:
+
+- ``SymbolicDivergence`` -- Generalized online detector combining a symbol
+  encoder, a divergence, and a change-point statistic.
+- ``SymbolicDivergenceConfiguration`` -- Configuration dataclass for
+  ``SymbolicDivergence``.
+- ``SymbolicDivergenceState`` -- State snapshot for ``SymbolicDivergence``.
+- ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
+- ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
+- ``IDivergence`` -- Protocol for divergence functions.
+- ``KLDivergence`` -- Kullback-Leibler divergence with smoothing.
+- ``IChangePointStatistic`` -- Protocol for divergence-to-statistic mappings.
+- ``RawDivergenceStatistic`` -- Identity change-point statistic (default).
+- ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``
+  statistic (``scale = 2.0`` reproduces ``2 n D``).
+
 Notes
 -----
 All algorithms require a ``learning_period_size`` of initial observations for

--- a/pysatl_cpd/algorithms/__init__.py
+++ b/pysatl_cpd/algorithms/__init__.py
@@ -84,6 +84,18 @@ Symbolic Divergence algorithms:
   ``SlopeKLSymbolicDivergence``.
 - ``SlopeKLSymbolicDivergenceState`` -- State snapshot for
   ``SlopeKLSymbolicDivergence``.
+- ``WindowedSymbolicDivergence`` -- Abstract, generic windowed detector
+  comparing a fixed recent window of symbols against a growing reference.
+- ``WindowedSymbolicDivergenceConfiguration`` -- Base configuration dataclass
+  for the windowed detector (adds ``recent_window_size``).
+- ``WindowedSymbolicDivergenceState`` -- Base state snapshot for the windowed
+  detector.
+- ``WindowedSlopeKLSymbolicDivergence`` -- Concrete windowed slope-encoder +
+  KL-divergence detector.
+- ``WindowedSlopeKLSymbolicDivergenceConfiguration`` -- Configuration for
+  ``WindowedSlopeKLSymbolicDivergence``.
+- ``WindowedSlopeKLSymbolicDivergenceState`` -- State snapshot for
+  ``WindowedSlopeKLSymbolicDivergence``.
 - ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
 - ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
 - ``IDivergence`` -- Protocol for divergence functions.
@@ -92,6 +104,8 @@ Symbolic Divergence algorithms:
 - ``RawDivergenceStatistic`` -- Identity change-point statistic (default).
 - ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``
   statistic (``scale = 2.0`` reproduces ``2 n D``).
+- ``LogScaledDivergenceStatistic`` -- ``scale * sample_size /
+  log(sample_size + 1) * divergence`` statistic.
 
 Notes
 -----

--- a/pysatl_cpd/algorithms/online/__init__.py
+++ b/pysatl_cpd/algorithms/online/__init__.py
@@ -28,7 +28,8 @@ configuration/state dataclasses from four subpackages:
 - ``symbolic_divergence`` -- A generalized symbolic-encoding detector that
   monitors the divergence between the running empirical symbol distribution
   and a reference distribution, with pluggable encoder, divergence, and
-  change-point statistic components. See the
+  change-point statistic components. A windowed variant compares a fixed
+  recent window of symbols against a growing reference. See the
   :mod:`~pysatl_cpd.algorithms.online.symbolic_divergence` docstring for
   details.
 
@@ -100,6 +101,18 @@ Symbolic Divergence algorithms (from ``symbolic_divergence``):
   ``SlopeKLSymbolicDivergence``.
 - ``SlopeKLSymbolicDivergenceState`` -- State snapshot for
   ``SlopeKLSymbolicDivergence``.
+- ``WindowedSymbolicDivergence`` -- Abstract, generic windowed detector
+  comparing a fixed recent window of symbols against a growing reference.
+- ``WindowedSymbolicDivergenceConfiguration`` -- Base configuration dataclass
+  for the windowed detector (adds ``recent_window_size``).
+- ``WindowedSymbolicDivergenceState`` -- Base state snapshot for the windowed
+  detector.
+- ``WindowedSlopeKLSymbolicDivergence`` -- Concrete windowed slope-encoder +
+  KL-divergence detector.
+- ``WindowedSlopeKLSymbolicDivergenceConfiguration`` -- Configuration for
+  ``WindowedSlopeKLSymbolicDivergence``.
+- ``WindowedSlopeKLSymbolicDivergenceState`` -- State snapshot for
+  ``WindowedSlopeKLSymbolicDivergence``.
 - ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
 - ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
 - ``IDivergence`` -- Protocol for divergence functions.
@@ -108,6 +121,8 @@ Symbolic Divergence algorithms (from ``symbolic_divergence``):
 - ``RawDivergenceStatistic`` -- Identity change-point statistic (default).
 - ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``
   statistic (``scale = 2.0`` reproduces ``2 n D``).
+- ``LogScaledDivergenceStatistic`` -- ``scale * sample_size /
+  log(sample_size + 1) * divergence`` statistic.
 
 Notes
 -----
@@ -206,6 +221,7 @@ from pysatl_cpd.algorithms.online.symbolic_divergence import (
     IDivergence,
     ISymbolEncoder,
     KLDivergence,
+    LogScaledDivergenceStatistic,
     RawDivergenceStatistic,
     ScaledDivergenceStatistic,
     SlopeEncoder,
@@ -215,6 +231,12 @@ from pysatl_cpd.algorithms.online.symbolic_divergence import (
     SymbolicDivergence,
     SymbolicDivergenceConfiguration,
     SymbolicDivergenceState,
+    WindowedSlopeKLSymbolicDivergence,
+    WindowedSlopeKLSymbolicDivergenceConfiguration,
+    WindowedSlopeKLSymbolicDivergenceState,
+    WindowedSymbolicDivergence,
+    WindowedSymbolicDivergenceConfiguration,
+    WindowedSymbolicDivergenceState,
 )
 
 __all__ = [
@@ -232,6 +254,7 @@ __all__ = [
     "IDivergence",
     "ISymbolEncoder",
     "KLDivergence",
+    "LogScaledDivergenceStatistic",
     "PageTwoSidedCusum",
     "PageTwoSidedCusumConfiguration",
     "PageTwoSidedCusumState",
@@ -253,4 +276,10 @@ __all__ = [
     "VarianceTwoSidedCUSUM",
     "VarianceTwoSidedCusumConfiguration",
     "VarianceTwoSidedCusumState",
+    "WindowedSlopeKLSymbolicDivergence",
+    "WindowedSlopeKLSymbolicDivergenceConfiguration",
+    "WindowedSlopeKLSymbolicDivergenceState",
+    "WindowedSymbolicDivergence",
+    "WindowedSymbolicDivergenceConfiguration",
+    "WindowedSymbolicDivergenceState",
 ]

--- a/pysatl_cpd/algorithms/online/__init__.py
+++ b/pysatl_cpd/algorithms/online/__init__.py
@@ -9,7 +9,7 @@ compatible with ``OnlineResetDetector``, ``OnlineCpdSolver``, runtime
 wrappers, and the benchmarking framework.
 
 The package re-exports concrete algorithms and their associated
-configuration/state dataclasses from three subpackages:
+configuration/state dataclasses from four subpackages:
 
 - ``bayesian`` -- Bayesian online change-point detection (BOCPD) following
   the Adams and MacKay (2007) message-passing framework. Includes an
@@ -25,6 +25,12 @@ configuration/state dataclasses from three subpackages:
   Page's two-sided CUSUM, the Crosier multivariate statistic, variance
   change detection, and autoregressive time series detection. See the
   :mod:`~pysatl_cpd.algorithms.online.cusum` docstring for details.
+- ``symbolic_divergence`` -- A generalized symbolic-encoding detector that
+  monitors the divergence between the running empirical symbol distribution
+  and a reference distribution, with pluggable encoder, divergence, and
+  change-point statistic components. See the
+  :mod:`~pysatl_cpd.algorithms.online.symbolic_divergence` docstring for
+  details.
 
 The ``classification`` directory is an internal implementation detail and
 is not part of the public API.
@@ -81,6 +87,22 @@ CUSUM algorithms (from ``cusum``):
 - ``AutoregressiveCusumConfiguration`` -- Configuration dataclass for
   ``AutoregressiveCUSUM``.
 - ``AutoregressiveCusumState`` -- State snapshot for ``AutoregressiveCUSUM``.
+
+Symbolic Divergence algorithms (from ``symbolic_divergence``):
+
+- ``SymbolicDivergence`` -- Generalized online detector combining a symbol
+  encoder, a divergence, and a change-point statistic.
+- ``SymbolicDivergenceConfiguration`` -- Configuration dataclass for
+  ``SymbolicDivergence``.
+- ``SymbolicDivergenceState`` -- State snapshot for ``SymbolicDivergence``.
+- ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
+- ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
+- ``IDivergence`` -- Protocol for divergence functions.
+- ``KLDivergence`` -- Kullback-Leibler divergence with smoothing.
+- ``IChangePointStatistic`` -- Protocol for divergence-to-statistic mappings.
+- ``RawDivergenceStatistic`` -- Identity change-point statistic (default).
+- ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``
+  statistic (``scale = 2.0`` reproduces ``2 n D``).
 
 Notes
 -----
@@ -174,6 +196,18 @@ from pysatl_cpd.algorithms.online.cusum.algorithm import (
     VarianceTwoSidedCusumConfiguration,
     VarianceTwoSidedCusumState,
 )
+from pysatl_cpd.algorithms.online.symbolic_divergence import (
+    IChangePointStatistic,
+    IDivergence,
+    ISymbolEncoder,
+    KLDivergence,
+    RawDivergenceStatistic,
+    ScaledDivergenceStatistic,
+    SlopeEncoder,
+    SymbolicDivergence,
+    SymbolicDivergenceConfiguration,
+    SymbolicDivergenceState,
+)
 
 __all__ = [
     "AbstractBayesian",
@@ -186,12 +220,22 @@ __all__ = [
     "CrosierCusum",
     "CrosierCusumConfiguration",
     "CrosierCusumState",
+    "IChangePointStatistic",
+    "IDivergence",
+    "ISymbolEncoder",
+    "KLDivergence",
     "PageTwoSidedCusum",
     "PageTwoSidedCusumConfiguration",
     "PageTwoSidedCusumState",
+    "RawDivergenceStatistic",
+    "ScaledDivergenceStatistic",
     "ShewhartControlChart",
     "ShewhartControlChartConfiguration",
     "ShewhartControlChartState",
+    "SlopeEncoder",
+    "SymbolicDivergence",
+    "SymbolicDivergenceConfiguration",
+    "SymbolicDivergenceState",
     "UnivariateGaussianConjugateBOCPD",
     "UnivariateGaussianConjugateBOCPDConfiguration",
     "UnivariateGaussianConjugateBOCPDState",

--- a/pysatl_cpd/algorithms/online/__init__.py
+++ b/pysatl_cpd/algorithms/online/__init__.py
@@ -90,11 +90,16 @@ CUSUM algorithms (from ``cusum``):
 
 Symbolic Divergence algorithms (from ``symbolic_divergence``):
 
-- ``SymbolicDivergence`` -- Generalized online detector combining a symbol
+- ``SymbolicDivergence`` -- Abstract, generic base detector combining a symbol
   encoder, a divergence, and a change-point statistic.
-- ``SymbolicDivergenceConfiguration`` -- Configuration dataclass for
-  ``SymbolicDivergence``.
-- ``SymbolicDivergenceState`` -- State snapshot for ``SymbolicDivergence``.
+- ``SymbolicDivergenceConfiguration`` -- Base configuration dataclass.
+- ``SymbolicDivergenceState`` -- Base state snapshot.
+- ``SlopeKLSymbolicDivergence`` -- Concrete slope-encoder + KL-divergence
+  detector storing component parameters in its configuration.
+- ``SlopeKLSymbolicDivergenceConfiguration`` -- Configuration for
+  ``SlopeKLSymbolicDivergence``.
+- ``SlopeKLSymbolicDivergenceState`` -- State snapshot for
+  ``SlopeKLSymbolicDivergence``.
 - ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
 - ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
 - ``IDivergence`` -- Protocol for divergence functions.
@@ -204,6 +209,9 @@ from pysatl_cpd.algorithms.online.symbolic_divergence import (
     RawDivergenceStatistic,
     ScaledDivergenceStatistic,
     SlopeEncoder,
+    SlopeKLSymbolicDivergence,
+    SlopeKLSymbolicDivergenceConfiguration,
+    SlopeKLSymbolicDivergenceState,
     SymbolicDivergence,
     SymbolicDivergenceConfiguration,
     SymbolicDivergenceState,
@@ -233,6 +241,9 @@ __all__ = [
     "ShewhartControlChartConfiguration",
     "ShewhartControlChartState",
     "SlopeEncoder",
+    "SlopeKLSymbolicDivergence",
+    "SlopeKLSymbolicDivergenceConfiguration",
+    "SlopeKLSymbolicDivergenceState",
     "SymbolicDivergence",
     "SymbolicDivergenceConfiguration",
     "SymbolicDivergenceState",

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
@@ -29,13 +29,20 @@ case of a broader family:
 
     <h2>Public API</h2>
 
-Algorithm:
+Algorithms:
 
-- ``SymbolicDivergence`` -- Generalized online detector combining a symbol
-  encoder, a divergence, and a change-point statistic.
-- ``SymbolicDivergenceConfiguration`` -- Configuration dataclass for
-  ``SymbolicDivergence``.
-- ``SymbolicDivergenceState`` -- State snapshot for ``SymbolicDivergence``.
+- ``SymbolicDivergence`` -- Abstract, generic online detector combining a
+  symbol encoder, a divergence, and a change-point statistic. Subclass it to
+  build concrete detectors.
+- ``SymbolicDivergenceConfiguration`` -- Base configuration dataclass.
+- ``SymbolicDivergenceState`` -- Base state snapshot.
+- ``SlopeKLSymbolicDivergence`` -- Concrete detector using a slope encoder and
+  Kullback-Leibler divergence; stores component parameters in its
+  configuration.
+- ``SlopeKLSymbolicDivergenceConfiguration`` -- Configuration for
+  ``SlopeKLSymbolicDivergence``.
+- ``SlopeKLSymbolicDivergenceState`` -- State snapshot for
+  ``SlopeKLSymbolicDivergence``.
 
 Encoder components (from ``encoders``):
 
@@ -61,6 +68,11 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 from pysatl_cpd.algorithms.online.symbolic_divergence.divergences import IDivergence, KLDivergence
 from pysatl_cpd.algorithms.online.symbolic_divergence.encoders import ISymbolEncoder, SlopeEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.slope_kl_symbolic_divergence import (
+    SlopeKLSymbolicDivergence,
+    SlopeKLSymbolicDivergenceConfiguration,
+    SlopeKLSymbolicDivergenceState,
+)
 from pysatl_cpd.algorithms.online.symbolic_divergence.statistics import (
     IChangePointStatistic,
     RawDivergenceStatistic,
@@ -80,6 +92,9 @@ __all__ = [
     "RawDivergenceStatistic",
     "ScaledDivergenceStatistic",
     "SlopeEncoder",
+    "SlopeKLSymbolicDivergence",
+    "SlopeKLSymbolicDivergenceConfiguration",
+    "SlopeKLSymbolicDivergenceState",
     "SymbolicDivergence",
     "SymbolicDivergenceConfiguration",
     "SymbolicDivergenceState",

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
@@ -9,6 +9,10 @@ between the running empirical symbol distribution and a reference distribution
 fixed at the end of the learning period. The divergence stream is then mapped
 to the emitted change-point statistic by a pluggable statistic component.
 
+A windowed sibling, :class:`WindowedSymbolicDivergence`, instead compares a
+fixed-size recent window of symbols against a reference that keeps growing as
+symbols leave that window.
+
 The exported class implements the ``OnlineAlgorithm`` interface from
 ``pysatl_cpd.core.online`` and is compatible with ``OnlineResetDetector``,
 ``OnlineCpdSolver``, runtime wrappers, and the benchmarking framework.
@@ -43,6 +47,18 @@ Algorithms:
   ``SlopeKLSymbolicDivergence``.
 - ``SlopeKLSymbolicDivergenceState`` -- State snapshot for
   ``SlopeKLSymbolicDivergence``.
+- ``WindowedSymbolicDivergence`` -- Abstract, generic windowed detector
+  comparing a fixed recent window of symbols against a growing reference.
+- ``WindowedSymbolicDivergenceConfiguration`` -- Base configuration dataclass
+  for the windowed detector (adds ``recent_window_size``).
+- ``WindowedSymbolicDivergenceState`` -- Base state snapshot for the windowed
+  detector.
+- ``WindowedSlopeKLSymbolicDivergence`` -- Concrete windowed detector using a
+  slope encoder and Kullback-Leibler divergence.
+- ``WindowedSlopeKLSymbolicDivergenceConfiguration`` -- Configuration for
+  ``WindowedSlopeKLSymbolicDivergence``.
+- ``WindowedSlopeKLSymbolicDivergenceState`` -- State snapshot for
+  ``WindowedSlopeKLSymbolicDivergence``.
 
 Encoder components (from ``encoders``):
 
@@ -59,6 +75,8 @@ Change-point statistic components (from ``statistics``):
 - ``IChangePointStatistic`` -- Protocol for divergence-to-statistic mappings.
 - ``RawDivergenceStatistic`` -- Identity statistic (default).
 - ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``.
+- ``LogScaledDivergenceStatistic`` -- ``scale * sample_size /
+  log(sample_size + 1) * divergence``.
 """
 
 __author__ = "Yulia Burmistrova"
@@ -75,6 +93,7 @@ from pysatl_cpd.algorithms.online.symbolic_divergence.slope_kl_symbolic_divergen
 )
 from pysatl_cpd.algorithms.online.symbolic_divergence.statistics import (
     IChangePointStatistic,
+    LogScaledDivergenceStatistic,
     RawDivergenceStatistic,
     ScaledDivergenceStatistic,
 )
@@ -83,12 +102,23 @@ from pysatl_cpd.algorithms.online.symbolic_divergence.symbolic_divergence import
     SymbolicDivergenceConfiguration,
     SymbolicDivergenceState,
 )
+from pysatl_cpd.algorithms.online.symbolic_divergence.windowed_slope_kl_symbolic_divergence import (
+    WindowedSlopeKLSymbolicDivergence,
+    WindowedSlopeKLSymbolicDivergenceConfiguration,
+    WindowedSlopeKLSymbolicDivergenceState,
+)
+from pysatl_cpd.algorithms.online.symbolic_divergence.windowed_symbolic_divergence import (
+    WindowedSymbolicDivergence,
+    WindowedSymbolicDivergenceConfiguration,
+    WindowedSymbolicDivergenceState,
+)
 
 __all__ = [
     "IChangePointStatistic",
     "IDivergence",
     "ISymbolEncoder",
     "KLDivergence",
+    "LogScaledDivergenceStatistic",
     "RawDivergenceStatistic",
     "ScaledDivergenceStatistic",
     "SlopeEncoder",
@@ -98,4 +128,10 @@ __all__ = [
     "SymbolicDivergence",
     "SymbolicDivergenceConfiguration",
     "SymbolicDivergenceState",
+    "WindowedSlopeKLSymbolicDivergence",
+    "WindowedSlopeKLSymbolicDivergenceConfiguration",
+    "WindowedSlopeKLSymbolicDivergenceState",
+    "WindowedSymbolicDivergence",
+    "WindowedSymbolicDivergenceConfiguration",
+    "WindowedSymbolicDivergenceState",
 ]

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: ascii -*-
+"""
+Symbolic Divergence online change-point detection.
+
+This package implements :class:`SymbolicDivergence`, a generalized online
+change-point detector that encodes a sliding window of observations into a
+symbol via a pluggable encoder (``h: R^k -> S``) and monitors the divergence
+between the empirical symbol distribution and a reference distribution learned
+during the warm-up period.
+
+The method is parameterized by two interchangeable components:
+
+- a symbol encoder implementing ``ISymbolEncoder`` (the ``SlopeEncoder`` with
+  ``k = 2`` is the canonical special case),
+- a divergence function implementing ``IDivergence`` (Kullback-Leibler being
+  one option).
+
+Public exports are wired up once the algorithm and its components are in place.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/__init__.py
@@ -5,19 +5,82 @@ Symbolic Divergence online change-point detection.
 This package implements :class:`SymbolicDivergence`, a generalized online
 change-point detector that encodes a sliding window of observations into a
 symbol via a pluggable encoder (``h: R^k -> S``) and monitors the divergence
-between the empirical symbol distribution and a reference distribution learned
-during the warm-up period.
+between the running empirical symbol distribution and a reference distribution
+fixed at the end of the learning period. The divergence stream is then mapped
+to the emitted change-point statistic by a pluggable statistic component.
 
-The method is parameterized by two interchangeable components:
+The exported class implements the ``OnlineAlgorithm`` interface from
+``pysatl_cpd.core.online`` and is compatible with ``OnlineResetDetector``,
+``OnlineCpdSolver``, runtime wrappers, and the benchmarking framework.
+
+The method is parameterized by three interchangeable components, so the
+Slope-encoding + Kullback-Leibler + ``2 n D`` combination is a single special
+case of a broader family:
 
 - a symbol encoder implementing ``ISymbolEncoder`` (the ``SlopeEncoder`` with
   ``k = 2`` is the canonical special case),
 - a divergence function implementing ``IDivergence`` (Kullback-Leibler being
-  one option).
+  one option),
+- a change-point statistic implementing ``IChangePointStatistic``
+  (``RawDivergenceStatistic`` by default, ``ScaledDivergenceStatistic`` for the
+  ``2 n D`` statistic).
 
-Public exports are wired up once the algorithm and its components are in place.
+.. raw:: html
+
+    <h2>Public API</h2>
+
+Algorithm:
+
+- ``SymbolicDivergence`` -- Generalized online detector combining a symbol
+  encoder, a divergence, and a change-point statistic.
+- ``SymbolicDivergenceConfiguration`` -- Configuration dataclass for
+  ``SymbolicDivergence``.
+- ``SymbolicDivergenceState`` -- State snapshot for ``SymbolicDivergence``.
+
+Encoder components (from ``encoders``):
+
+- ``ISymbolEncoder`` -- Protocol for window-to-symbol encoders.
+- ``SlopeEncoder`` -- Two-point slope encoder (``k = 2``).
+
+Divergence components (from ``divergences``):
+
+- ``IDivergence`` -- Protocol for divergence functions.
+- ``KLDivergence`` -- Kullback-Leibler divergence with smoothing.
+
+Change-point statistic components (from ``statistics``):
+
+- ``IChangePointStatistic`` -- Protocol for divergence-to-statistic mappings.
+- ``RawDivergenceStatistic`` -- Identity statistic (default).
+- ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``.
 """
 
 __author__ = "Yulia Burmistrova"
 __copyright__ = "Copyright (c) 2026 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
+
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences import IDivergence, KLDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders import ISymbolEncoder, SlopeEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics import (
+    IChangePointStatistic,
+    RawDivergenceStatistic,
+    ScaledDivergenceStatistic,
+)
+from pysatl_cpd.algorithms.online.symbolic_divergence.symbolic_divergence import (
+    SymbolicDivergence,
+    SymbolicDivergenceConfiguration,
+    SymbolicDivergenceState,
+)
+
+__all__ = [
+    "IChangePointStatistic",
+    "IDivergence",
+    "ISymbolEncoder",
+    "KLDivergence",
+    "RawDivergenceStatistic",
+    "ScaledDivergenceStatistic",
+    "SlopeEncoder",
+    "SymbolicDivergence",
+    "SymbolicDivergenceConfiguration",
+    "SymbolicDivergenceState",
+]

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: ascii -*-
+"""
+Divergence functions for the Symbolic Divergence algorithm.
+
+This package provides the divergence interface and concrete divergences that
+quantify the discrepancy between an empirical symbol distribution and a
+reference distribution.
+
+.. raw:: html
+
+    <h2>Public API</h2>
+
+- ``IDivergence`` -- Protocol for divergences between discrete distributions.
+  Any class implementing ``compute`` and ``reset`` is compatible.
+- ``KLDivergence`` -- Kullback-Leibler divergence with additive smoothing.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.base import IDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.kl_divergence import KLDivergence
+
+__all__ = ["IDivergence", "KLDivergence"]

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/base.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/base.py
@@ -18,7 +18,13 @@ from pysatl_cpd.typedefs import UnivariateNumericArray
 
 
 class IDivergence(Protocol):
-    """Interface for divergences between discrete probability distributions."""
+    """Interface for divergences between discrete symbol distributions.
+
+    The two arguments are non-negative symbol frequencies: either raw counts
+    or already-normalised probabilities. They need not sum to one;
+    implementations are expected to normalise internally. The divergence is a
+    pure function and therefore stateless (no ``reset`` is required).
+    """
 
     def compute(self, empirical: UnivariateNumericArray, reference: UnivariateNumericArray) -> float:
         """Compute the divergence ``D(empirical || reference)``.
@@ -26,19 +32,13 @@ class IDivergence(Protocol):
         Parameters
         ----------
         empirical
-            Empirical symbol frequencies. Non-negative and summing to one.
+            Empirical symbol frequencies (raw counts or probabilities).
+            Non-negative; need not sum to one.
         reference
-            Reference symbol probabilities. Non-negative and summing to one.
+            Reference symbol frequencies (raw counts or probabilities).
+            Non-negative; need not sum to one.
 
         Returns
         -------
         float
-        """
-
-    def reset(self) -> None:
-        """Reset internal state, if any.
-
-        Returns
-        -------
-        None
         """

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/base.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/base.py
@@ -1,0 +1,44 @@
+# -*- coding: ascii -*-
+"""
+Protocol definition for divergence functions.
+
+This module defines :class:`IDivergence`, the structural typing interface
+(PEP 544 protocol) for divergences between two discrete probability
+distributions over a symbol alphabet, consumed by the Symbolic Divergence
+algorithm.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from typing import Protocol
+
+from pysatl_cpd.typedefs import UnivariateNumericArray
+
+
+class IDivergence(Protocol):
+    """Interface for divergences between discrete probability distributions."""
+
+    def compute(self, empirical: UnivariateNumericArray, reference: UnivariateNumericArray) -> float:
+        """Compute the divergence ``D(empirical || reference)``.
+
+        Parameters
+        ----------
+        empirical
+            Empirical symbol frequencies. Non-negative and summing to one.
+        reference
+            Reference symbol probabilities. Non-negative and summing to one.
+
+        Returns
+        -------
+        float
+        """
+
+    def reset(self) -> None:
+        """Reset internal state, if any.
+
+        Returns
+        -------
+        None
+        """

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/kl_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/kl_divergence.py
@@ -3,8 +3,11 @@
 Kullback-Leibler divergence for the Symbolic Divergence algorithm.
 
 This module provides :class:`KLDivergence`, a stateless implementation of the
-Kullback-Leibler divergence ``D_KL(p || q) = sum(p * log(p / q))`` with
-additive smoothing to keep both distributions strictly positive.
+Kullback-Leibler divergence ``D_KL(p || q) = sum(p * log(p / q))``. Inputs may
+be raw symbol frequencies (counts) or probabilities; they are normalised
+internally. Additive smoothing is applied to the reference distribution to keep
+it strictly positive, and the divergence is evaluated in a numerically stable
+log-difference form that tolerates zero counts and very large counts.
 """
 
 __author__ = "Yulia Burmistrova"
@@ -18,16 +21,26 @@ from pysatl_cpd.typedefs import UnivariateNumericArray
 
 
 class KLDivergence(IDivergence):
-    """Kullback-Leibler divergence with additive smoothing.
+    """Kullback-Leibler divergence with additive smoothing of the reference.
 
-    Both distributions are shifted by ``smoothing`` and renormalised before
-    the divergence is evaluated, which avoids ``log(0)`` and division by zero
-    when a symbol is unobserved in either distribution.
+    Inputs may be raw symbol frequencies (counts) or probabilities; both are
+    normalised internally. Only the reference distribution is smoothed by
+    ``smoothing`` so that symbols unobserved during the learning period do not
+    produce ``log(0)`` or division by zero. Symbols with zero empirical
+    frequency contribute nothing (``0 * log 0 = 0``) and are skipped.
+
+    The divergence is evaluated as
+
+    .. math::
+        D = \\frac{\\sum_i p_i (\\log p_i - \\log q_i)}{\\sum_i p_i}
+
+    over the smoothed/normalised distributions, which stays numerically stable
+    for frequencies that differ by many orders of magnitude.
 
     Parameters
     ----------
     smoothing
-        Non-negative additive smoothing constant. Must be non-negative.
+        Non-negative additive smoothing constant applied to the reference.
 
     Raises
     ------
@@ -42,33 +55,37 @@ class KLDivergence(IDivergence):
         self._smoothing = smoothing
 
     def compute(self, empirical: UnivariateNumericArray, reference: UnivariateNumericArray) -> float:
-        """Compute ``D_KL(empirical || reference)`` with smoothing.
+        """Compute ``D_KL(empirical || reference)``.
 
         Parameters
         ----------
         empirical
-            Empirical symbol frequencies. Non-negative and summing to one.
+            Empirical symbol frequencies (raw counts or probabilities).
+            Non-negative; need not sum to one.
         reference
-            Reference symbol probabilities. Non-negative and summing to one.
+            Reference symbol frequencies (raw counts or probabilities).
+            Non-negative; need not sum to one.
 
         Returns
         -------
         float
         """
-        p = empirical + self._smoothing
-        q = reference + self._smoothing
-        p = p / p.sum()
-        q = q / q.sum()
-        return float(np.sum(p * np.log(p / q)))
+        p = np.asarray(empirical, dtype=np.float64)
+        q = np.asarray(reference, dtype=np.float64)
 
-    def reset(self) -> None:
-        """Reset internal state (the divergence is stateless).
+        positive = p > 0.0
+        if not np.any(positive):
+            return 0.0
 
-        Returns
-        -------
-        None
-        """
-        return None
+        p_total = float(p.sum())
+        q_total = float(q.sum()) + self._smoothing * float(q.size)
+
+        p_pos = p[positive]
+        q_pos = q[positive] + self._smoothing
+
+        log_p = np.log(p_pos) - np.log(p_total)
+        log_q = np.log(q_pos) - np.log(q_total)
+        return float(np.sum(p_pos * (log_p - log_q)) / p_total)
 
     def __repr__(self) -> str:
         return f"KLDivergence(smoothing={self._smoothing!r})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/kl_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/divergences/kl_divergence.py
@@ -1,0 +1,74 @@
+# -*- coding: ascii -*-
+"""
+Kullback-Leibler divergence for the Symbolic Divergence algorithm.
+
+This module provides :class:`KLDivergence`, a stateless implementation of the
+Kullback-Leibler divergence ``D_KL(p || q) = sum(p * log(p / q))`` with
+additive smoothing to keep both distributions strictly positive.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import numpy as np
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.base import IDivergence
+from pysatl_cpd.typedefs import UnivariateNumericArray
+
+
+class KLDivergence(IDivergence):
+    """Kullback-Leibler divergence with additive smoothing.
+
+    Both distributions are shifted by ``smoothing`` and renormalised before
+    the divergence is evaluated, which avoids ``log(0)`` and division by zero
+    when a symbol is unobserved in either distribution.
+
+    Parameters
+    ----------
+    smoothing
+        Non-negative additive smoothing constant. Must be non-negative.
+
+    Raises
+    ------
+    ValueError
+        If ``smoothing`` is negative.
+    """
+
+    def __init__(self, smoothing: float = 1e-10) -> None:
+        if smoothing < 0.0:
+            raise ValueError(f"smoothing must be non-negative, got {smoothing}")
+
+        self._smoothing = smoothing
+
+    def compute(self, empirical: UnivariateNumericArray, reference: UnivariateNumericArray) -> float:
+        """Compute ``D_KL(empirical || reference)`` with smoothing.
+
+        Parameters
+        ----------
+        empirical
+            Empirical symbol frequencies. Non-negative and summing to one.
+        reference
+            Reference symbol probabilities. Non-negative and summing to one.
+
+        Returns
+        -------
+        float
+        """
+        p = empirical + self._smoothing
+        q = reference + self._smoothing
+        p = p / p.sum()
+        q = q / q.sum()
+        return float(np.sum(p * np.log(p / q)))
+
+    def reset(self) -> None:
+        """Reset internal state (the divergence is stateless).
+
+        Returns
+        -------
+        None
+        """
+        return None
+
+    def __repr__(self) -> str:
+        return f"KLDivergence(smoothing={self._smoothing!r})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: ascii -*-
+"""
+Symbol encoders for the Symbolic Divergence algorithm.
+
+This package provides the encoder interface and concrete encoders that map a
+window of consecutive observations to a discrete symbol (``h: R^k -> S``).
+
+.. raw:: html
+
+    <h2>Public API</h2>
+
+- ``ISymbolEncoder`` -- Protocol for window-to-symbol encodings. Any class
+  implementing ``window_size``, ``num_symbols``, ``symbols``, ``encode``, and
+  ``reset`` is compatible.
+- ``SlopeEncoder`` -- Canonical ``k = 2`` encoder mapping the slope between two
+  consecutive observations to ``{-2, -1, 0, 1, 2}``.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.base import ISymbolEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.slope_encoder import SlopeEncoder
+
+__all__ = ["ISymbolEncoder", "SlopeEncoder"]

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/base.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/base.py
@@ -1,0 +1,74 @@
+# -*- coding: ascii -*-
+"""
+Protocol definition for symbol encoders.
+
+This module defines :class:`ISymbolEncoder`, the structural typing interface
+(PEP 544 protocol) for window-to-symbol encodings ``h: R^k -> S`` consumed by
+the Symbolic Divergence algorithm.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from collections.abc import Hashable, Sequence
+from typing import Protocol
+
+from pysatl_cpd.typedefs import Number
+
+
+class ISymbolEncoder[SymbolT: Hashable](Protocol):
+    """Interface for window-to-symbol encodings ``h: R^k -> S``.
+
+    Implementations map a fixed-size window of ``window_size`` consecutive
+    observations to a single symbol drawn from a finite alphabet exposed via
+    ``symbols``.
+    """
+
+    @property
+    def window_size(self) -> int:
+        """Number of observations per window (``k``).
+
+        Returns
+        -------
+        int
+        """
+
+    @property
+    def num_symbols(self) -> int:
+        """Size of the symbol alphabet ``|S|``.
+
+        Returns
+        -------
+        int
+        """
+
+    @property
+    def symbols(self) -> tuple[SymbolT, ...]:
+        """All possible symbols in canonical (index) order.
+
+        Returns
+        -------
+        tuple[SymbolT, ...]
+        """
+
+    def encode(self, window: Sequence[Number]) -> SymbolT:
+        """Encode a window of ``window_size`` observations into a symbol.
+
+        Parameters
+        ----------
+        window
+            Sequence of the most recent ``window_size`` observations.
+
+        Returns
+        -------
+        SymbolT
+        """
+
+    def reset(self) -> None:
+        """Reset internal encoder state, if any.
+
+        Returns
+        -------
+        None
+        """

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/slope_encoder.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/slope_encoder.py
@@ -1,0 +1,129 @@
+# -*- coding: ascii -*-
+"""
+Slope encoder for the Symbolic Divergence algorithm.
+
+This module provides :class:`SlopeEncoder`, the canonical ``k = 2`` special
+case of :class:`ISymbolEncoder`. It maps the difference between two
+consecutive observations to one of five ordinal symbols
+``{-2, -1, 0, 1, 2}`` using two thresholds.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from collections.abc import Sequence
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.base import ISymbolEncoder
+from pysatl_cpd.typedefs import Number
+
+
+class SlopeEncoder(ISymbolEncoder[int]):
+    """Two-observation slope encoder ``h(x_i, x_{i+1}) = encode(x_{i+1} - x_i)``.
+
+    The signed difference ``d = x_{i+1} - x_i`` is mapped to a symbol via:
+
+    - ``d < -gamma``           -> ``-2``
+    - ``-gamma <= d < -delta`` -> ``-1``
+    - ``-delta <= d <= delta`` -> ``0``
+    - ``delta < d <= gamma``   -> ``1``
+    - ``d > gamma``            -> ``2``
+
+    Parameters
+    ----------
+    delta
+        Inner (dead-zone) threshold for the flat symbol. Must be non-negative.
+    gamma
+        Outer threshold for steep symbols. Must be strictly greater than
+        ``delta``.
+
+    Raises
+    ------
+    ValueError
+        If ``delta`` is negative or ``gamma`` is not strictly greater than
+        ``delta``.
+    """
+
+    _SYMBOLS: tuple[int, ...] = (-2, -1, 0, 1, 2)
+
+    def __init__(self, delta: float, gamma: float) -> None:
+        if delta < 0.0:
+            raise ValueError(f"delta must be non-negative, got {delta}")
+        if gamma <= delta:
+            raise ValueError(f"gamma ({gamma}) must be strictly greater than delta ({delta})")
+
+        self._delta = delta
+        self._gamma = gamma
+
+    @property
+    def window_size(self) -> int:
+        """Number of observations per window (``k = 2``).
+
+        Returns
+        -------
+        int
+        """
+        return 2
+
+    @property
+    def num_symbols(self) -> int:
+        """Size of the symbol alphabet (``|S| = 5``).
+
+        Returns
+        -------
+        int
+        """
+        return len(self._SYMBOLS)
+
+    @property
+    def symbols(self) -> tuple[int, ...]:
+        """Ordinal symbols in canonical order ``(-2, -1, 0, 1, 2)``.
+
+        Returns
+        -------
+        tuple[int, ...]
+        """
+        return self._SYMBOLS
+
+    def encode(self, window: Sequence[Number]) -> int:
+        """Encode the slope of the last two observations into a symbol.
+
+        Parameters
+        ----------
+        window
+            Sequence whose last two elements are used as ``(x_i, x_{i+1})``.
+
+        Returns
+        -------
+        int
+
+        Raises
+        ------
+        ValueError
+            If ``window`` contains fewer than two observations.
+        """
+        if len(window) < 2:
+            raise ValueError(f"window must contain at least 2 observations, got {len(window)}")
+
+        diff = window[-1] - window[-2]
+        if diff < -self._gamma:
+            return -2
+        if diff < -self._delta:
+            return -1
+        if diff <= self._delta:
+            return 0
+        if diff <= self._gamma:
+            return 1
+        return 2
+
+    def reset(self) -> None:
+        """Reset internal state (the slope encoder is stateless).
+
+        Returns
+        -------
+        None
+        """
+        return None
+
+    def __repr__(self) -> str:
+        return f"SlopeEncoder(delta={self._delta!r}, gamma={self._gamma!r})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/slope_encoder.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/encoders/slope_encoder.py
@@ -49,6 +49,8 @@ class SlopeEncoder(ISymbolEncoder[int]):
     def __init__(self, delta: float, gamma: float) -> None:
         if delta < 0.0:
             raise ValueError(f"delta must be non-negative, got {delta}")
+        if gamma <= 0.0:
+            raise ValueError(f"gamma must be positive, got {gamma}")
         if gamma <= delta:
             raise ValueError(f"gamma ({gamma}) must be strictly greater than delta ({delta})")
 

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/slope_kl_symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/slope_kl_symbolic_divergence.py
@@ -1,0 +1,154 @@
+# -*- coding: ascii -*-
+"""
+Slope + Kullback-Leibler Symbolic Divergence detector.
+
+This module provides :class:`SlopeKLSymbolicDivergence`, the canonical concrete
+Symbolic Divergence detector combining the two-point :class:`SlopeEncoder` with
+the :class:`KLDivergence`. Its configuration stores the component parameters
+(``delta``, ``gamma``, ``smoothing``) as scalars, so distinct detector instances
+hash differently and are correctly identified by the benchmarking framework.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from dataclasses import dataclass
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.kl_divergence import KLDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.slope_encoder import SlopeEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.scaled import ScaledDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.symbolic_divergence import (
+    SymbolicDivergence,
+    SymbolicDivergenceConfiguration,
+    SymbolicDivergenceState,
+)
+
+
+@dataclass(kw_only=True, frozen=True)
+class SlopeKLSymbolicDivergenceConfiguration(SymbolicDivergenceConfiguration):
+    """
+    Configuration for the Slope + Kullback-Leibler Symbolic Divergence detector.
+
+    The slope-encoder and divergence parameters are stored here as scalars so
+    they participate in the configuration hash used to identify the detector.
+
+    Attributes
+    ----------
+    delta
+        Inner (dead-zone) threshold of the slope encoder.
+    gamma
+        Outer threshold of the slope encoder.
+    smoothing
+        Additive smoothing constant of the Kullback-Leibler divergence.
+
+    Raises
+    ------
+    ValueError
+        If ``learning_period_size`` is not positive.
+    """
+
+    delta: float = 0.0
+    gamma: float = 1.0
+    smoothing: float = 1e-10
+
+    def __repr__(self) -> str:
+        """Return a short string representation of the configuration."""
+        return f"delta={self.delta}, gamma={self.gamma}, smoothing={self.smoothing}"
+
+
+@dataclass(kw_only=True, frozen=True)
+class SlopeKLSymbolicDivergenceState(SymbolicDivergenceState):
+    """State snapshot of the Slope + Kullback-Leibler Symbolic Divergence detector."""
+
+
+class SlopeKLSymbolicDivergence(
+    SymbolicDivergence[SlopeKLSymbolicDivergenceConfiguration, SlopeKLSymbolicDivergenceState]
+):
+    """
+    Symbolic Divergence detector using a slope encoder and KL divergence.
+
+    This is the canonical concrete detector: a two-point :class:`SlopeEncoder`
+    feeds a :class:`KLDivergence`, with the change-point statistic chosen via the
+    ``statistic`` argument (raw divergence by default).
+
+    Parameters
+    ----------
+    learning_period_size
+        Number of initial observations used to estimate the reference
+        distribution. Must be strictly greater than the slope window size (2).
+    delta
+        Inner (dead-zone) threshold of the slope encoder. Must be non-negative.
+    gamma
+        Outer threshold of the slope encoder. Must be positive and strictly
+        greater than ``delta``.
+    smoothing
+        Additive smoothing constant of the KL divergence. Must be non-negative.
+    statistic
+        Change-point statistic implementing ``IChangePointStatistic``. Defaults
+        to ``ScaledDivergenceStatistic`` (the ``2 n D`` statistic).
+
+    Notes
+    -----
+    Parameter validation is delegated: ``learning_period_size`` is checked by
+    the configuration and against the slope window size, while ``delta``,
+    ``gamma``, and ``smoothing`` are validated by the slope encoder and the KL
+    divergence. Each raises ``ValueError`` on invalid input.
+    """
+
+    def __init__(
+        self,
+        learning_period_size: int,
+        delta: float,
+        gamma: float,
+        smoothing: float = 1e-10,
+        statistic: IChangePointStatistic | None = None,
+    ) -> None:
+        configuration = SlopeKLSymbolicDivergenceConfiguration(
+            learning_period_size=learning_period_size,
+            delta=delta,
+            gamma=gamma,
+            smoothing=smoothing,
+        )
+        super().__init__(
+            configuration=configuration,
+            encoder=SlopeEncoder(delta=delta, gamma=gamma),
+            divergence=KLDivergence(smoothing=smoothing),
+            statistic=statistic if statistic is not None else ScaledDivergenceStatistic(),
+        )
+
+    @property
+    def name(self) -> str:
+        """Human-readable algorithm name.
+
+        Returns
+        -------
+        str
+        """
+        return "SlopeKLSymbolicDivergence"
+
+    @property
+    def configuration(self) -> SlopeKLSymbolicDivergenceConfiguration:
+        """Current algorithm configuration.
+
+        Returns
+        -------
+        SlopeKLSymbolicDivergenceConfiguration
+        """
+        return self._configuration
+
+    @property
+    def state(self) -> SlopeKLSymbolicDivergenceState:
+        """Materialise an immutable state snapshot.
+
+        Returns
+        -------
+        SlopeKLSymbolicDivergenceState
+        """
+        return SlopeKLSymbolicDivergenceState(
+            is_in_learning_period=self.is_in_learning_period,
+            samples_count=self.samples_count,
+            symbol_counts=self.symbol_counts,
+            reference_distribution=self.reference_distribution,
+        )

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: ascii -*-
+"""
+Change-point statistics for the Symbolic Divergence algorithm.
+
+This package provides the interface and concrete implementations that turn the
+stream of divergence values into the final change-point statistic compared
+against a threshold by the detector. It plays the same role as the CUSUM
+change-point function.
+
+.. raw:: html
+
+    <h2>Public API</h2>
+
+- ``IChangePointStatistic`` -- Protocol for divergence-to-statistic mappings.
+  Any class implementing ``update``, ``value``, and ``reset`` is compatible.
+- ``RawDivergenceStatistic`` -- Identity statistic returning the latest
+  divergence unchanged (default).
+- ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``; with
+  ``scale = 2.0`` this reproduces the ``2 n D`` statistic.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.scaled import ScaledDivergenceStatistic
+
+__all__ = ["IChangePointStatistic", "RawDivergenceStatistic", "ScaledDivergenceStatistic"]

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/__init__.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/__init__.py
@@ -17,6 +17,9 @@ change-point function.
   divergence unchanged (default).
 - ``ScaledDivergenceStatistic`` -- ``scale * sample_size * divergence``; with
   ``scale = 2.0`` this reproduces the ``2 n D`` statistic.
+- ``LogScaledDivergenceStatistic`` -- ``scale * sample_size /
+  log(sample_size + 1) * divergence``; a logarithmically damped variant of the
+  linear scaling.
 """
 
 __author__ = "Yulia Burmistrova"
@@ -25,7 +28,13 @@ __license__ = "SPDX-License-Identifier: MIT"
 
 
 from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.log_scaled import LogScaledDivergenceStatistic
 from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
 from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.scaled import ScaledDivergenceStatistic
 
-__all__ = ["IChangePointStatistic", "RawDivergenceStatistic", "ScaledDivergenceStatistic"]
+__all__ = [
+    "IChangePointStatistic",
+    "LogScaledDivergenceStatistic",
+    "RawDivergenceStatistic",
+    "ScaledDivergenceStatistic",
+]

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/base.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/base.py
@@ -1,0 +1,49 @@
+# -*- coding: ascii -*-
+"""
+Protocol definition for change-point statistics.
+
+This module defines :class:`IChangePointStatistic`, the structural typing
+interface (PEP 544 protocol) for components that turn the stream of divergence
+values into the final change-point statistic compared against a threshold by
+the detector. It mirrors the role of the CUSUM change-point function.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from typing import Protocol
+
+
+class IChangePointStatistic(Protocol):
+    """Interface mapping a divergence stream into a change-point statistic."""
+
+    def update(self, divergence: float, sample_size: int) -> None:
+        """Incorporate a new divergence value into the statistic.
+
+        Parameters
+        ----------
+        divergence
+            Divergence between the empirical and reference distributions at the
+            current step.
+        sample_size
+            Number of symbols accumulated so far (``n``), available for
+            sample-size-dependent statistics such as ``2 n D``.
+        """
+
+    @property
+    def value(self) -> float:
+        """Current change-point statistic value.
+
+        Returns
+        -------
+        float
+        """
+
+    def reset(self) -> None:
+        """Reset internal state.
+
+        Returns
+        -------
+        None
+        """

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/log_scaled.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/log_scaled.py
@@ -1,0 +1,75 @@
+# -*- coding: ascii -*-
+"""
+Log-scaled change-point statistic for the Symbolic Divergence algorithm.
+
+This module provides :class:`LogScaledDivergenceStatistic`, which scales the
+divergence by ``scale * sample_size / log(sample_size + 1)``. Compared with the
+linear ``scale * sample_size`` growth of :class:`ScaledDivergenceStatistic`, the
+logarithmic denominator damps the statistic when the number of symbols backing
+the empirical distribution is large, which is useful for the windowed detector.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import math
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+
+
+class LogScaledDivergenceStatistic(IChangePointStatistic):
+    """Statistic ``scale * sample_size / log(sample_size + 1) * divergence``.
+
+    Parameters
+    ----------
+    scale
+        Non-negative multiplier. The default is ``2.0``.
+
+    Raises
+    ------
+    ValueError
+        If ``scale`` is negative.
+    """
+
+    def __init__(self, scale: float = 2.0) -> None:
+        if scale < 0.0:
+            raise ValueError(f"scale must be non-negative, got {scale}")
+
+        self._scale = scale
+        self._value = 0.0
+
+    def update(self, divergence: float, sample_size: int) -> None:
+        """Scale the divergence by ``scale * sample_size / log(sample_size + 1)``.
+
+        Parameters
+        ----------
+        divergence
+            Divergence at the current step.
+        sample_size
+            Number of symbols represented by the current empirical
+            distribution. Must be positive.
+        """
+        self._value = self._scale * (sample_size / math.log(sample_size + 1)) * divergence
+
+    @property
+    def value(self) -> float:
+        """Current log-scaled statistic value.
+
+        Returns
+        -------
+        float
+        """
+        return self._value
+
+    def reset(self) -> None:
+        """Reset the stored value to zero.
+
+        Returns
+        -------
+        None
+        """
+        self._value = 0.0
+
+    def __repr__(self) -> str:
+        return f"LogScaledDivergenceStatistic(scale={self._scale!r})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/raw.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/raw.py
@@ -1,0 +1,55 @@
+# -*- coding: ascii -*-
+"""
+Identity change-point statistic for the Symbolic Divergence algorithm.
+
+This module provides :class:`RawDivergenceStatistic`, which returns the latest
+divergence value unchanged. It is the default statistic and preserves the
+algorithm's raw-divergence behaviour.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+
+
+class RawDivergenceStatistic(IChangePointStatistic):
+    """Identity statistic: the value equals the latest divergence."""
+
+    def __init__(self) -> None:
+        self._value = 0.0
+
+    def update(self, divergence: float, sample_size: int) -> None:
+        """Store the latest divergence as the current statistic.
+
+        Parameters
+        ----------
+        divergence
+            Divergence at the current step.
+        sample_size
+            Number of accumulated symbols (unused by this statistic).
+        """
+        self._value = divergence
+
+    @property
+    def value(self) -> float:
+        """Current statistic value (the latest divergence).
+
+        Returns
+        -------
+        float
+        """
+        return self._value
+
+    def reset(self) -> None:
+        """Reset the stored value to zero.
+
+        Returns
+        -------
+        None
+        """
+        self._value = 0.0
+
+    def __repr__(self) -> str:
+        return "RawDivergenceStatistic()"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/scaled.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/statistics/scaled.py
@@ -1,0 +1,72 @@
+# -*- coding: ascii -*-
+"""
+Sample-size-scaled change-point statistic for the Symbolic Divergence algorithm.
+
+This module provides :class:`ScaledDivergenceStatistic`, which scales the
+divergence by ``scale * sample_size``. With the default ``scale = 2.0`` and the
+Kullback-Leibler divergence this yields the ``2 n D_n`` statistic studied in the
+theory of the method.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+
+
+class ScaledDivergenceStatistic(IChangePointStatistic):
+    """Statistic ``scale * sample_size * divergence``.
+
+    Parameters
+    ----------
+    scale
+        Non-negative multiplier. The default ``2.0`` reproduces the ``2 n D``
+        statistic.
+
+    Raises
+    ------
+    ValueError
+        If ``scale`` is negative.
+    """
+
+    def __init__(self, scale: float = 2.0) -> None:
+        if scale < 0.0:
+            raise ValueError(f"scale must be non-negative, got {scale}")
+
+        self._scale = scale
+        self._value = 0.0
+
+    def update(self, divergence: float, sample_size: int) -> None:
+        """Scale the divergence by ``scale * sample_size``.
+
+        Parameters
+        ----------
+        divergence
+            Divergence at the current step.
+        sample_size
+            Number of accumulated symbols (``n``).
+        """
+        self._value = self._scale * sample_size * divergence
+
+    @property
+    def value(self) -> float:
+        """Current scaled statistic value.
+
+        Returns
+        -------
+        float
+        """
+        return self._value
+
+    def reset(self) -> None:
+        """Reset the stored value to zero.
+
+        Returns
+        -------
+        None
+        """
+        self._value = 0.0
+
+    def __repr__(self) -> str:
+        return f"ScaledDivergenceStatistic(scale={self._scale!r})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/symbolic_divergence.py
@@ -11,12 +11,21 @@ to a change-point statistic via a pluggable component.
 The encoding (``h: R^k -> S``), divergence, and change-point statistic are
 pluggable components, which makes the Slope-encoding + Kullback-Leibler +
 ``2 n D`` combination a single special case of a broader family.
+
+:class:`SymbolicDivergence` is an abstract base that is generic over its
+configuration and state types, mirroring the ``GeneralizedCUSUM`` design.
+Concrete detectors (such as ``SlopeKLSymbolicDivergence``) subclass it, bake
+their component parameters into a dedicated frozen configuration, and implement
+the ``configuration`` and ``state`` properties. Keeping the component parameters
+in the configuration is what lets distinct detector instances hash differently
+in the benchmarking framework.
 """
 
 __author__ = "Yulia Burmistrova"
 __copyright__ = "Copyright (c) 2026 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from abc import abstractmethod
 from collections import deque
 from copy import deepcopy
 from dataclasses import dataclass
@@ -105,9 +114,12 @@ class SymbolicDivergenceConfiguration(OnlineAlgorithmConfiguration):
         return stable_hash((type(self).__module__, type(self).__qualname__, self.learning_period_size))
 
 
-class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration, SymbolicDivergenceState]):
+class SymbolicDivergence[
+    ConfigurationT: SymbolicDivergenceConfiguration,
+    StateT: SymbolicDivergenceState,
+](OnlineAlgorithm[Number, ConfigurationT, StateT]):
     """
-    Online change-point detector based on symbolic encoding and divergence.
+    Abstract online change-point detector based on symbolic encoding.
 
     During the learning period the algorithm encodes each sliding window of
     ``encoder.window_size`` observations into a symbol, accumulates the symbol
@@ -116,15 +128,17 @@ class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration
     distribution and that reference, then delegates the final emitted value to
     the change-point statistic component.
 
-    No threshold is applied here; thresholding is the responsibility of the
-    detector (for example ``OnlineResetDetector``).
+    The class is generic over its configuration and state types so that
+    concrete detectors can extend both. Subclasses build a configuration that
+    stores the component parameters and implement the ``configuration`` and
+    ``state`` properties. No threshold is applied here; thresholding is the
+    responsibility of the detector (for example ``OnlineResetDetector``).
 
     Parameters
     ----------
-    learning_period_size
-        Number of initial observations used to estimate the reference
-        distribution. Must be positive and strictly greater than
-        ``encoder.window_size``.
+    configuration
+        Algorithm configuration. Its ``learning_period_size`` must be strictly
+        greater than ``encoder.window_size``.
     encoder
         Window-to-symbol encoder implementing ``ISymbolEncoder``.
     divergence
@@ -137,24 +151,24 @@ class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration
     Raises
     ------
     ValueError
-        If ``learning_period_size`` is not positive, or is not strictly
-        greater than ``encoder.window_size``.
+        If ``configuration.learning_period_size`` is not strictly greater than
+        ``encoder.window_size``.
     """
 
     def __init__(
         self,
-        learning_period_size: int,
+        configuration: ConfigurationT,
         encoder: ISymbolEncoder[int],
         divergence: IDivergence,
         statistic: IChangePointStatistic | None = None,
     ) -> None:
-        self._configuration = SymbolicDivergenceConfiguration(learning_period_size=learning_period_size)
-        if learning_period_size <= encoder.window_size:
+        if configuration.learning_period_size <= encoder.window_size:
             raise ValueError(
-                f"learning_period_size ({learning_period_size}) must be strictly greater "
-                f"than encoder.window_size ({encoder.window_size})"
+                f"learning_period_size ({configuration.learning_period_size}) must be strictly "
+                f"greater than encoder.window_size ({encoder.window_size})"
             )
 
+        self._configuration = configuration
         self._encoder = encoder
         self._divergence = divergence
         self._statistic: IChangePointStatistic = statistic if statistic is not None else RawDivergenceStatistic()
@@ -194,39 +208,52 @@ class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration
         return self._statistic
 
     @property
-    def name(self) -> str:
-        """Human-readable algorithm name.
+    def samples_count(self) -> int:
+        """Number of observations processed so far.
 
         Returns
         -------
-        str
+        int
         """
-        return "SymbolicDivergence"
+        return self._samples_count
 
     @property
-    def configuration(self) -> SymbolicDivergenceConfiguration:
-        """Current algorithm configuration.
+    def symbol_counts(self) -> tuple[int, ...]:
+        """Cumulative per-symbol counts in canonical (encoder) order.
 
         Returns
         -------
-        SymbolicDivergenceConfiguration
+        tuple[int, ...]
         """
-        return self._configuration
+        return tuple(self._symbol_counts)
 
     @property
-    def state(self) -> SymbolicDivergenceState:
-        """Materialise an immutable state snapshot.
+    def reference_distribution(self) -> tuple[float, ...]:
+        """Reference distribution fixed at the end of the learning period.
 
         Returns
         -------
-        SymbolicDivergenceState
+        tuple[float, ...]
         """
-        return SymbolicDivergenceState(
-            is_in_learning_period=self._samples_count <= self._configuration.learning_period_size,
-            samples_count=self._samples_count,
-            symbol_counts=tuple(self._symbol_counts),
-            reference_distribution=(tuple(self._reference.tolist()) if self._reference is not None else ()),
-        )
+        return tuple(self._reference.tolist()) if self._reference is not None else ()
+
+    @property
+    def is_in_learning_period(self) -> bool:
+        """Whether the algorithm is still within its learning period.
+
+        Returns
+        -------
+        bool
+        """
+        return self._samples_count <= self._configuration.learning_period_size
+
+    @property
+    @abstractmethod
+    def configuration(self) -> ConfigurationT: ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def state(self) -> StateT: ...  # pragma: no cover
 
     def process(self, observation: Number) -> Number:
         """Ingest one observation and return the change-point statistic.

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/symbolic_divergence.py
@@ -273,15 +273,13 @@ class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration
         """Reset the algorithm to its initial state.
 
         Clears the sliding window, symbol counts, reference distribution, and
-        sample counter, and resets the encoder, divergence, and statistic
-        components.
+        sample counter, and resets the encoder and statistic components.
 
         Returns
         -------
         None
         """
         self._encoder.reset()
-        self._divergence.reset()
         self._statistic.reset()
         self._window.clear()
         self._symbol_counts = [0] * self._encoder.num_symbols
@@ -298,7 +296,3 @@ class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration
         algorithm = deepcopy(self)
         algorithm.reset()
         return algorithm
-
-    def __repr__(self) -> str:
-        """Return a string representation of the algorithm with its configuration."""
-        return f"SymbolicDivergence({self._configuration})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/symbolic_divergence.py
@@ -1,0 +1,304 @@
+# -*- coding: ascii -*-
+"""
+Symbolic Divergence online change-point detection algorithm.
+
+This module provides :class:`SymbolicDivergence`, a generalized online detector
+that encodes a sliding window of observations into a symbol, computes a
+divergence between the running empirical symbol distribution and a reference
+distribution fixed at the end of the learning period, and maps that divergence
+to a change-point statistic via a pluggable component.
+
+The encoding (``h: R^k -> S``), divergence, and change-point statistic are
+pluggable components, which makes the Slope-encoding + Kullback-Leibler +
+``2 n D`` combination a single special case of a broader family.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from collections import deque
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Self
+
+import numpy as np
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.base import IDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.base import ISymbolEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.core.online.ionline_algorithm import (
+    OnlineAlgorithm,
+    OnlineAlgorithmConfiguration,
+    OnlineAlgorithmState,
+)
+from pysatl_cpd.typedefs import Number, UnivariateNumericArray, stable_hash
+
+
+@dataclass(kw_only=True, frozen=True)
+class SymbolicDivergenceState(OnlineAlgorithmState):
+    """
+    State snapshot of the Symbolic Divergence algorithm.
+
+    Attributes
+    ----------
+    samples_count
+        Number of observations processed so far.
+    symbol_counts
+        Cumulative per-symbol counts in canonical (encoder) order.
+    reference_distribution
+        Reference symbol distribution fixed at the end of the learning period,
+        or an empty tuple while still learning.
+    """
+
+    samples_count: int = 0
+    symbol_counts: tuple[int, ...] = ()
+    reference_distribution: tuple[float, ...] = ()
+
+    def __hash__(self) -> int:
+        """Return a stable hash for the Symbolic Divergence state snapshot."""
+        return stable_hash(
+            (
+                type(self).__module__,
+                type(self).__qualname__,
+                self.is_in_learning_period,
+                self.samples_count,
+                self.symbol_counts,
+                self.reference_distribution,
+            )
+        )
+
+
+@dataclass(kw_only=True, frozen=True)
+class SymbolicDivergenceConfiguration(OnlineAlgorithmConfiguration):
+    """
+    Configuration parameters for the Symbolic Divergence algorithm.
+
+    The encoder, divergence, and statistic components are passed as objects to
+    the algorithm and are intentionally not stored here, matching the component
+    pattern used by the generalized CUSUM detectors.
+
+    Raises
+    ------
+    ValueError
+        If ``learning_period_size`` is not positive.
+    """
+
+    def __post_init__(self) -> None:
+        """Validate configuration parameters.
+
+        Raises
+        ------
+        ValueError
+            If ``learning_period_size`` is not positive.
+        """
+        if self.learning_period_size <= 0:
+            raise ValueError(f"learning_period_size must be positive, got {self.learning_period_size}")
+
+    def __repr__(self) -> str:
+        """Return a short string representation of the configuration."""
+        return f"learning_period_size={self.learning_period_size}"
+
+    def __hash__(self) -> int:
+        """Return a stable hash for the Symbolic Divergence configuration."""
+        return stable_hash((type(self).__module__, type(self).__qualname__, self.learning_period_size))
+
+
+class SymbolicDivergence(OnlineAlgorithm[Number, SymbolicDivergenceConfiguration, SymbolicDivergenceState]):
+    """
+    Online change-point detector based on symbolic encoding and divergence.
+
+    During the learning period the algorithm encodes each sliding window of
+    ``encoder.window_size`` observations into a symbol, accumulates the symbol
+    frequencies, and fixes them as the reference distribution. After the
+    learning period it computes the divergence between the running empirical
+    distribution and that reference, then delegates the final emitted value to
+    the change-point statistic component.
+
+    No threshold is applied here; thresholding is the responsibility of the
+    detector (for example ``OnlineResetDetector``).
+
+    Parameters
+    ----------
+    learning_period_size
+        Number of initial observations used to estimate the reference
+        distribution. Must be positive and strictly greater than
+        ``encoder.window_size``.
+    encoder
+        Window-to-symbol encoder implementing ``ISymbolEncoder``.
+    divergence
+        Divergence function implementing ``IDivergence``.
+    statistic
+        Change-point statistic implementing ``IChangePointStatistic`` that maps
+        the divergence stream to the emitted value. Defaults to
+        ``RawDivergenceStatistic`` (the raw divergence).
+
+    Raises
+    ------
+    ValueError
+        If ``learning_period_size`` is not positive, or is not strictly
+        greater than ``encoder.window_size``.
+    """
+
+    def __init__(
+        self,
+        learning_period_size: int,
+        encoder: ISymbolEncoder[int],
+        divergence: IDivergence,
+        statistic: IChangePointStatistic | None = None,
+    ) -> None:
+        self._configuration = SymbolicDivergenceConfiguration(learning_period_size=learning_period_size)
+        if learning_period_size <= encoder.window_size:
+            raise ValueError(
+                f"learning_period_size ({learning_period_size}) must be strictly greater "
+                f"than encoder.window_size ({encoder.window_size})"
+            )
+
+        self._encoder = encoder
+        self._divergence = divergence
+        self._statistic: IChangePointStatistic = statistic if statistic is not None else RawDivergenceStatistic()
+        self._window: deque[Number] = deque(maxlen=encoder.window_size)
+        self._symbol_counts: list[int] = [0] * encoder.num_symbols
+        self._reference: UnivariateNumericArray | None = None
+        self._samples_count: int = 0
+
+    @property
+    def encoder(self) -> ISymbolEncoder[int]:
+        """Symbol encoder component.
+
+        Returns
+        -------
+        ISymbolEncoder[int]
+        """
+        return self._encoder
+
+    @property
+    def divergence(self) -> IDivergence:
+        """Divergence component.
+
+        Returns
+        -------
+        IDivergence
+        """
+        return self._divergence
+
+    @property
+    def statistic(self) -> IChangePointStatistic:
+        """Change-point statistic component.
+
+        Returns
+        -------
+        IChangePointStatistic
+        """
+        return self._statistic
+
+    @property
+    def name(self) -> str:
+        """Human-readable algorithm name.
+
+        Returns
+        -------
+        str
+        """
+        return "SymbolicDivergence"
+
+    @property
+    def configuration(self) -> SymbolicDivergenceConfiguration:
+        """Current algorithm configuration.
+
+        Returns
+        -------
+        SymbolicDivergenceConfiguration
+        """
+        return self._configuration
+
+    @property
+    def state(self) -> SymbolicDivergenceState:
+        """Materialise an immutable state snapshot.
+
+        Returns
+        -------
+        SymbolicDivergenceState
+        """
+        return SymbolicDivergenceState(
+            is_in_learning_period=self._samples_count <= self._configuration.learning_period_size,
+            samples_count=self._samples_count,
+            symbol_counts=tuple(self._symbol_counts),
+            reference_distribution=(tuple(self._reference.tolist()) if self._reference is not None else ()),
+        )
+
+    def process(self, observation: Number) -> Number:
+        """Ingest one observation and return the change-point statistic.
+
+        The sliding window is updated and, once full, encoded into a symbol
+        whose count is accumulated. Returns 0 during the learning period or
+        before the first full window; afterwards computes the divergence
+        between the running empirical distribution and the fixed reference and
+        maps it to the emitted statistic.
+
+        Parameters
+        ----------
+        observation
+            New scalar observation.
+
+        Returns
+        -------
+        Number
+        """
+        self._samples_count += 1
+        self._window.append(observation)
+
+        if len(self._window) < self._encoder.window_size:
+            return 0.0
+
+        symbol = self._encoder.encode(list(self._window))
+        self._symbol_counts[self._encoder.symbols.index(symbol)] += 1
+        sample_size = sum(self._symbol_counts)
+
+        counts = np.asarray(self._symbol_counts, dtype=np.float64)
+        empirical: UnivariateNumericArray = counts / sample_size
+
+        if self._samples_count == self._configuration.learning_period_size:
+            self._reference = empirical.copy()
+
+        if self._samples_count <= self._configuration.learning_period_size or self._reference is None:
+            return 0.0
+
+        divergence = self._divergence.compute(empirical, self._reference)
+        self._statistic.update(divergence, sample_size)
+        return self._statistic.value
+
+    def reset(self) -> None:
+        """Reset the algorithm to its initial state.
+
+        Clears the sliding window, symbol counts, reference distribution, and
+        sample counter, and resets the encoder, divergence, and statistic
+        components.
+
+        Returns
+        -------
+        None
+        """
+        self._encoder.reset()
+        self._divergence.reset()
+        self._statistic.reset()
+        self._window.clear()
+        self._symbol_counts = [0] * self._encoder.num_symbols
+        self._reference = None
+        self._samples_count = 0
+
+    def recreate(self) -> Self:
+        """Create a fresh copy with identical configuration and reset state.
+
+        Returns
+        -------
+        Self
+        """
+        algorithm = deepcopy(self)
+        algorithm.reset()
+        return algorithm
+
+    def __repr__(self) -> str:
+        """Return a string representation of the algorithm with its configuration."""
+        return f"SymbolicDivergence({self._configuration})"

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/windowed_slope_kl_symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/windowed_slope_kl_symbolic_divergence.py
@@ -1,0 +1,175 @@
+# -*- coding: ascii -*-
+"""
+Windowed Slope + Kullback-Leibler Symbolic Divergence detector.
+
+This module provides :class:`WindowedSlopeKLSymbolicDivergence`, the canonical
+concrete windowed Symbolic Divergence detector combining the two-point
+:class:`SlopeEncoder` with the :class:`KLDivergence`. Unlike
+:class:`SlopeKLSymbolicDivergence`, which compares the running cumulative symbol
+distribution against a reference fixed at the end of the learning period, this
+variant compares a fixed-size recent window of symbols against a reference that
+keeps growing as symbols leave that window.
+
+Its configuration stores the component parameters (``delta``, ``gamma``,
+``smoothing``) together with ``recent_window_size`` as scalars, so distinct
+detector instances hash differently and are correctly identified by the
+benchmarking framework. The change-point statistic defaults to the raw
+divergence (``RawDivergenceStatistic``).
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from dataclasses import dataclass
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.kl_divergence import KLDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.slope_encoder import SlopeEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.windowed_symbolic_divergence import (
+    WindowedSymbolicDivergence,
+    WindowedSymbolicDivergenceConfiguration,
+    WindowedSymbolicDivergenceState,
+)
+
+
+@dataclass(kw_only=True, frozen=True)
+class WindowedSlopeKLSymbolicDivergenceConfiguration(WindowedSymbolicDivergenceConfiguration):
+    """
+    Configuration for the windowed Slope + Kullback-Leibler Symbolic Divergence detector.
+
+    The slope-encoder and divergence parameters are stored here as scalars so
+    they participate in the configuration hash used to identify the detector.
+
+    Attributes
+    ----------
+    delta
+        Inner (dead-zone) threshold of the slope encoder.
+    gamma
+        Outer threshold of the slope encoder.
+    smoothing
+        Additive smoothing constant of the Kullback-Leibler divergence.
+
+    Raises
+    ------
+    ValueError
+        If ``learning_period_size`` or ``recent_window_size`` is not positive.
+    """
+
+    delta: float = 0.0
+    gamma: float = 1.0
+    smoothing: float = 1e-10
+
+    def __repr__(self) -> str:
+        """Return a short string representation of the configuration."""
+        return (
+            f"learning_period_size={self.learning_period_size}, "
+            f"recent_window_size={self.recent_window_size}, "
+            f"delta={self.delta}, gamma={self.gamma}, smoothing={self.smoothing}"
+        )
+
+
+@dataclass(kw_only=True, frozen=True)
+class WindowedSlopeKLSymbolicDivergenceState(WindowedSymbolicDivergenceState):
+    """State snapshot of the windowed Slope + Kullback-Leibler Symbolic Divergence detector."""
+
+
+class WindowedSlopeKLSymbolicDivergence(
+    WindowedSymbolicDivergence[WindowedSlopeKLSymbolicDivergenceConfiguration, WindowedSlopeKLSymbolicDivergenceState]
+):
+    """
+    Windowed Symbolic Divergence detector using a slope encoder and KL divergence.
+
+    This is the canonical concrete windowed detector: a two-point
+    :class:`SlopeEncoder` feeds a :class:`KLDivergence`, the empirical
+    distribution is taken over a fixed recent window, and the reference grows as
+    symbols leave that window. The change-point statistic is chosen via the
+    ``statistic`` argument (raw divergence by default).
+
+    Parameters
+    ----------
+    learning_period_size
+        Number of initial observations used to estimate the reference
+        distribution. Must be strictly greater than the slope window size (2).
+    recent_window_size
+        Number of recent post-learning observations whose symbols form the
+        empirical distribution. Must be strictly greater than the slope window
+        size (2).
+    delta
+        Inner (dead-zone) threshold of the slope encoder. Must be non-negative.
+    gamma
+        Outer threshold of the slope encoder. Must be positive and strictly
+        greater than ``delta``.
+    smoothing
+        Additive smoothing constant of the KL divergence. Must be non-negative.
+    statistic
+        Change-point statistic implementing ``IChangePointStatistic``. Defaults
+        to ``RawDivergenceStatistic`` (the raw divergence).
+
+    Notes
+    -----
+    Parameter validation is delegated: ``learning_period_size`` and
+    ``recent_window_size`` are checked by the configuration and against the
+    slope window size, while ``delta``, ``gamma``, and ``smoothing`` are
+    validated by the slope encoder and the KL divergence. Each raises
+    ``ValueError`` on invalid input.
+    """
+
+    def __init__(
+        self,
+        learning_period_size: int,
+        recent_window_size: int,
+        delta: float,
+        gamma: float,
+        smoothing: float = 1e-10,
+        statistic: IChangePointStatistic | None = None,
+    ) -> None:
+        configuration = WindowedSlopeKLSymbolicDivergenceConfiguration(
+            learning_period_size=learning_period_size,
+            recent_window_size=recent_window_size,
+            delta=delta,
+            gamma=gamma,
+            smoothing=smoothing,
+        )
+        super().__init__(
+            configuration=configuration,
+            encoder=SlopeEncoder(delta=delta, gamma=gamma),
+            divergence=KLDivergence(smoothing=smoothing),
+            statistic=statistic if statistic is not None else RawDivergenceStatistic(),
+        )
+
+    @property
+    def name(self) -> str:
+        """Human-readable algorithm name.
+
+        Returns
+        -------
+        str
+        """
+        return "WindowedSlopeKLSymbolicDivergence"
+
+    @property
+    def configuration(self) -> WindowedSlopeKLSymbolicDivergenceConfiguration:
+        """Current algorithm configuration.
+
+        Returns
+        -------
+        WindowedSlopeKLSymbolicDivergenceConfiguration
+        """
+        return self._configuration
+
+    @property
+    def state(self) -> WindowedSlopeKLSymbolicDivergenceState:
+        """Materialise an immutable state snapshot.
+
+        Returns
+        -------
+        WindowedSlopeKLSymbolicDivergenceState
+        """
+        return WindowedSlopeKLSymbolicDivergenceState(
+            is_in_learning_period=self.is_in_learning_period,
+            samples_count=self.samples_count,
+            symbol_counts=self.symbol_counts,
+            reference_distribution=self.reference_distribution,
+        )

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/windowed_symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/windowed_symbolic_divergence.py
@@ -1,0 +1,385 @@
+# -*- coding: ascii -*-
+"""
+Windowed Symbolic Divergence online change-point detection algorithm.
+
+This module provides :class:`WindowedSymbolicDivergence`, a generalized online
+detector that encodes a sliding window of observations into a symbol, computes a
+divergence between a recent-window empirical symbol distribution and a reference
+distribution updated with symbols that leave that window, and maps that
+divergence to a change-point statistic via a pluggable component.
+
+It is a sibling of :class:`SymbolicDivergence`: the latter compares the running
+(cumulative) empirical distribution against a reference fixed at the end of the
+learning period, whereas this windowed variant compares a fixed-size recent
+window against a reference that keeps growing with the observed past. The
+encoding (``h: R^k -> S``), divergence, and change-point statistic remain
+pluggable components.
+
+:class:`WindowedSymbolicDivergence` is an abstract base that is generic over its
+configuration and state types, mirroring the ``GeneralizedCUSUM`` design.
+Concrete detectors (such as ``WindowedSlopeKLSymbolicDivergence``) subclass it,
+bake their component parameters into a dedicated frozen configuration, and
+implement the ``configuration`` and ``state`` properties. Keeping the component
+parameters in the configuration is what lets distinct detector instances hash
+differently in the benchmarking framework.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from abc import abstractmethod
+from collections import deque
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Self
+
+import numpy as np
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.base import IDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.base import ISymbolEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.base import IChangePointStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.core.online.ionline_algorithm import (
+    OnlineAlgorithm,
+    OnlineAlgorithmConfiguration,
+    OnlineAlgorithmState,
+)
+from pysatl_cpd.typedefs import Number, UnivariateNumericArray, stable_hash
+
+
+@dataclass(kw_only=True, frozen=True)
+class WindowedSymbolicDivergenceState(OnlineAlgorithmState):
+    """
+    State snapshot of the windowed Symbolic Divergence algorithm.
+
+    Attributes
+    ----------
+    samples_count
+        Number of observations processed so far.
+    symbol_counts
+        Per-symbol counts in the current recent window, or the learning counts
+        accumulated so far while still learning, in canonical (encoder) order.
+    reference_distribution
+        Current reference symbol distribution, or an empty tuple while still
+        learning.
+    """
+
+    samples_count: int = 0
+    symbol_counts: tuple[int, ...] = ()
+    reference_distribution: tuple[float, ...] = ()
+
+    def __hash__(self) -> int:
+        """Return a stable hash for the windowed Symbolic Divergence state snapshot."""
+        return stable_hash(
+            (
+                type(self).__module__,
+                type(self).__qualname__,
+                self.is_in_learning_period,
+                self.samples_count,
+                self.symbol_counts,
+                self.reference_distribution,
+            )
+        )
+
+
+@dataclass(kw_only=True, frozen=True)
+class WindowedSymbolicDivergenceConfiguration(OnlineAlgorithmConfiguration):
+    """
+    Configuration parameters for the windowed Symbolic Divergence algorithm.
+
+    The encoder, divergence, and statistic components are passed as objects to
+    the algorithm and are intentionally not stored here, matching the component
+    pattern used by the generalized CUSUM detectors.
+
+    Attributes
+    ----------
+    recent_window_size
+        Number of recent post-learning observations whose symbols form the
+        empirical distribution compared against the reference.
+
+    Raises
+    ------
+    ValueError
+        If ``learning_period_size`` or ``recent_window_size`` is not positive.
+    """
+
+    recent_window_size: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate configuration parameters.
+
+        Raises
+        ------
+        ValueError
+            If ``learning_period_size`` or ``recent_window_size`` is not
+            positive.
+        """
+        if self.learning_period_size <= 0:
+            raise ValueError(f"learning_period_size must be positive, got {self.learning_period_size}")
+        if self.recent_window_size <= 0:
+            raise ValueError(f"recent_window_size must be positive, got {self.recent_window_size}")
+
+    def __repr__(self) -> str:
+        """Return a short string representation of the configuration."""
+        return f"learning_period_size={self.learning_period_size}, recent_window_size={self.recent_window_size}"
+
+    def __hash__(self) -> int:
+        """Return a stable hash for the windowed Symbolic Divergence configuration."""
+        return stable_hash(
+            (type(self).__module__, type(self).__qualname__, self.learning_period_size, self.recent_window_size)
+        )
+
+
+class WindowedSymbolicDivergence[
+    ConfigurationT: WindowedSymbolicDivergenceConfiguration,
+    StateT: WindowedSymbolicDivergenceState,
+](OnlineAlgorithm[Number, ConfigurationT, StateT]):
+    """
+    Abstract windowed online change-point detector based on symbolic encoding.
+
+    During the learning period the algorithm encodes each sliding window of
+    ``encoder.window_size`` observations into a symbol and accumulates the
+    symbol frequencies as the initial reference distribution. After the learning
+    period it fills a fixed recent window of symbols, computes the divergence
+    between that recent empirical distribution and the reference, and folds each
+    symbol that drops out of the recent window into the reference, so the
+    reference keeps growing with the observed past.
+
+    The class is generic over its configuration and state types so that concrete
+    detectors can extend both. Subclasses build a configuration that stores the
+    component parameters and implement the ``configuration`` and ``state``
+    properties. No threshold is applied here; thresholding is the responsibility
+    of the detector (for example ``OnlineResetDetector``).
+
+    Parameters
+    ----------
+    configuration
+        Algorithm configuration. Its ``learning_period_size`` and
+        ``recent_window_size`` must both be strictly greater than
+        ``encoder.window_size``.
+    encoder
+        Window-to-symbol encoder implementing ``ISymbolEncoder``.
+    divergence
+        Divergence function implementing ``IDivergence``.
+    statistic
+        Change-point statistic implementing ``IChangePointStatistic`` that maps
+        the divergence stream to the emitted value. Defaults to
+        ``RawDivergenceStatistic`` (the raw divergence).
+
+    Raises
+    ------
+    ValueError
+        If ``configuration.learning_period_size`` or
+        ``configuration.recent_window_size`` is not strictly greater than
+        ``encoder.window_size``.
+    """
+
+    def __init__(
+        self,
+        configuration: ConfigurationT,
+        encoder: ISymbolEncoder[int],
+        divergence: IDivergence,
+        statistic: IChangePointStatistic | None = None,
+    ) -> None:
+        if configuration.learning_period_size <= encoder.window_size:
+            raise ValueError(
+                f"learning_period_size ({configuration.learning_period_size}) must be strictly "
+                f"greater than encoder.window_size ({encoder.window_size})"
+            )
+        if configuration.recent_window_size <= encoder.window_size:
+            raise ValueError(
+                f"recent_window_size ({configuration.recent_window_size}) must be strictly "
+                f"greater than encoder.window_size ({encoder.window_size})"
+            )
+
+        self._configuration = configuration
+        self._encoder = encoder
+        self._divergence = divergence
+        self._statistic: IChangePointStatistic = statistic if statistic is not None else RawDivergenceStatistic()
+        self._window: deque[Number] = deque(maxlen=encoder.window_size)
+        self._symbol_counts: list[int] = [0] * encoder.num_symbols
+        self._recent_symbols_maxlen: int = configuration.recent_window_size - encoder.window_size + 1
+        self._recent_symbols: deque[int] = deque(maxlen=self._recent_symbols_maxlen)
+        self._reference_counts: UnivariateNumericArray | None = None
+        self._reference_sample_size: int = 0
+        self._reference: UnivariateNumericArray | None = None
+        self._samples_count: int = 0
+
+    @property
+    def encoder(self) -> ISymbolEncoder[int]:
+        """Symbol encoder component.
+
+        Returns
+        -------
+        ISymbolEncoder[int]
+        """
+        return self._encoder
+
+    @property
+    def divergence(self) -> IDivergence:
+        """Divergence component.
+
+        Returns
+        -------
+        IDivergence
+        """
+        return self._divergence
+
+    @property
+    def statistic(self) -> IChangePointStatistic:
+        """Change-point statistic component.
+
+        Returns
+        -------
+        IChangePointStatistic
+        """
+        return self._statistic
+
+    @property
+    def samples_count(self) -> int:
+        """Number of observations processed so far.
+
+        Returns
+        -------
+        int
+        """
+        return self._samples_count
+
+    @property
+    def symbol_counts(self) -> tuple[int, ...]:
+        """Per-symbol counts in canonical (encoder) order.
+
+        Returns
+        -------
+        tuple[int, ...]
+        """
+        return tuple(self._symbol_counts)
+
+    @property
+    def reference_distribution(self) -> tuple[float, ...]:
+        """Current reference distribution.
+
+        Returns
+        -------
+        tuple[float, ...]
+        """
+        return tuple(self._reference.tolist()) if self._reference is not None else ()
+
+    @property
+    def is_in_learning_period(self) -> bool:
+        """Whether the algorithm is still within its learning period.
+
+        Returns
+        -------
+        bool
+        """
+        return self._samples_count <= self._configuration.learning_period_size
+
+    @property
+    @abstractmethod
+    def configuration(self) -> ConfigurationT: ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def state(self) -> StateT: ...  # pragma: no cover
+
+    def process(self, observation: Number) -> Number:
+        """Ingest one observation and return the change-point statistic.
+
+        The sliding window is updated and, once full, encoded into a symbol.
+        During learning, symbols build the initial reference. After learning,
+        symbols populate a fixed recent window. Returns 0 until that window is
+        full; afterwards computes the divergence between the recent distribution
+        and the reference. When the recent window advances, the dropped symbol
+        is folded into the reference.
+
+        Parameters
+        ----------
+        observation
+            New scalar observation.
+
+        Returns
+        -------
+        Number
+        """
+        self._samples_count += 1
+        self._window.append(observation)
+
+        if len(self._window) < self._encoder.window_size:
+            return 0.0
+
+        symbol = self._encoder.encode(list(self._window))
+        symbol_index = self._encoder.symbols.index(symbol)
+
+        if self._samples_count == self._configuration.learning_period_size:
+            self._symbol_counts[symbol_index] += 1
+            learning_counts = np.asarray(self._symbol_counts, dtype=np.float64)
+            self._reference_counts = learning_counts
+            self._reference_sample_size = int(learning_counts.sum())
+            self._reference = learning_counts / self._reference_sample_size
+            self._symbol_counts = [0] * self._encoder.num_symbols
+            self._window.clear()
+            return 0.0
+
+        if self._samples_count < self._configuration.learning_period_size:
+            self._symbol_counts[symbol_index] += 1
+            return 0.0
+
+        reference_counts = self._reference_counts
+        reference = self._reference
+        if reference_counts is None or reference is None:
+            return 0.0
+
+        if len(self._recent_symbols) == self._recent_symbols_maxlen:
+            dropped_symbol_index = self._recent_symbols.popleft()
+            self._symbol_counts[dropped_symbol_index] -= 1
+            reference_counts[dropped_symbol_index] += 1.0
+            self._reference_sample_size += 1
+            reference = reference_counts / self._reference_sample_size
+            self._reference = reference
+
+        self._recent_symbols.append(symbol_index)
+        self._symbol_counts[symbol_index] += 1
+
+        if len(self._recent_symbols) < self._recent_symbols_maxlen:
+            return 0.0
+
+        sample_size = len(self._recent_symbols)
+        empirical: UnivariateNumericArray = np.asarray(self._symbol_counts, dtype=np.float64) / sample_size
+        divergence = self._divergence.compute(empirical, reference)
+        self._statistic.update(divergence, sample_size)
+
+        return self._statistic.value
+
+    def reset(self) -> None:
+        """Reset the algorithm to its initial state.
+
+        Clears the sliding window, recent window, symbol counts, reference
+        distribution, and sample counter, and resets the encoder and statistic
+        components.
+
+        Returns
+        -------
+        None
+        """
+        self._encoder.reset()
+        self._statistic.reset()
+        self._window.clear()
+        self._recent_symbols.clear()
+        self._symbol_counts = [0] * self._encoder.num_symbols
+        self._reference_counts = None
+        self._reference_sample_size = 0
+        self._reference = None
+        self._samples_count = 0
+
+    def recreate(self) -> Self:
+        """Create a fresh copy with identical configuration and reset state.
+
+        Returns
+        -------
+        Self
+        """
+        algorithm = deepcopy(self)
+        algorithm.reset()
+        return algorithm

--- a/pysatl_cpd/algorithms/online/symbolic_divergence/windowed_symbolic_divergence.py
+++ b/pysatl_cpd/algorithms/online/symbolic_divergence/windowed_symbolic_divergence.py
@@ -32,7 +32,7 @@ from abc import abstractmethod
 from collections import deque
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Self
+from typing import Self, cast
 
 import numpy as np
 
@@ -326,10 +326,8 @@ class WindowedSymbolicDivergence[
             self._symbol_counts[symbol_index] += 1
             return 0.0
 
-        reference_counts = self._reference_counts
-        reference = self._reference
-        if reference_counts is None or reference is None:
-            return 0.0
+        reference_counts = cast(UnivariateNumericArray, self._reference_counts)
+        reference = cast(UnivariateNumericArray, self._reference)
 
         if len(self._recent_symbols) == self._recent_symbols_maxlen:
             dropped_symbol_index = self._recent_symbols.popleft()

--- a/tests/golden/algorithms/slope_kl_symbolic_divergence.json
+++ b/tests/golden/algorithms/slope_kl_symbolic_divergence.json
@@ -1,0 +1,41 @@
+{
+  "algorithm": "SlopeKLSymbolicDivergence",
+  "final_state": {
+    "is_in_learning_period": false,
+    "reference_distribution": [
+      0.0,
+      0.5,
+      0.0,
+      0.5,
+      0.0
+    ],
+    "samples_count": 8,
+    "symbol_counts": [
+      1,
+      2,
+      0,
+      1,
+      3
+    ]
+  },
+  "observations": [
+    0.0,
+    1.0,
+    0.5,
+    2.0,
+    5.0,
+    -3.0,
+    0.2,
+    0.1
+  ],
+  "values": [
+    0.0,
+    0.0,
+    0.0,
+    42.232616852312034,
+    86.55822627848227,
+    127.60590390398129,
+    172.06995626823544,
+    170.48721089615736
+  ]
+}

--- a/tests/golden/algorithms/windowed_slope_kl_symbolic_divergence.json
+++ b/tests/golden/algorithms/windowed_slope_kl_symbolic_divergence.json
@@ -1,0 +1,41 @@
+{
+  "algorithm": "WindowedSlopeKLSymbolicDivergence",
+  "final_state": {
+    "is_in_learning_period": false,
+    "reference_distribution": [
+      0.0,
+      0.3333333333333333,
+      0.0,
+      0.3333333333333333,
+      0.3333333333333333
+    ],
+    "samples_count": 8,
+    "symbol_counts": [
+      1,
+      1,
+      0,
+      0,
+      1
+    ]
+  },
+  "observations": [
+    0.0,
+    1.0,
+    0.5,
+    2.0,
+    5.0,
+    -3.0,
+    0.2,
+    0.1
+  ],
+  "values": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    22.389336762145643,
+    7.309079547390781
+  ]
+}

--- a/tests/regression/test_algorithm_outputs.py
+++ b/tests/regression/test_algorithm_outputs.py
@@ -19,6 +19,7 @@ from pysatl_cpd.algorithms.online import (
     CrosierCusum,
     PageTwoSidedCusum,
     ShewhartControlChart,
+    SlopeKLSymbolicDivergence,
     UnivariateGaussianConjugateBOCPD,
     VarianceTwoSidedCUSUM,
 )
@@ -76,6 +77,10 @@ def _observation(value):
         (
             "autoregressive_cusum",
             AutoregressiveCUSUM(learning_period_size=5, delta=0.1, autoreg_order=1, adaptive_estimation=False),
+        ),
+        (
+            "slope_kl_symbolic_divergence",
+            SlopeKLSymbolicDivergence(learning_period_size=3, delta=0.0, gamma=1.0),
         ),
         (
             "univariate_gaussian_conjugate_bocpd",

--- a/tests/regression/test_algorithm_outputs.py
+++ b/tests/regression/test_algorithm_outputs.py
@@ -22,6 +22,7 @@ from pysatl_cpd.algorithms.online import (
     SlopeKLSymbolicDivergence,
     UnivariateGaussianConjugateBOCPD,
     VarianceTwoSidedCUSUM,
+    WindowedSlopeKLSymbolicDivergence,
 )
 from pysatl_cpd.algorithms.online.bayesian import BayesianCPFType
 from tests.support.golden import load_json_golden
@@ -81,6 +82,10 @@ def _observation(value):
         (
             "slope_kl_symbolic_divergence",
             SlopeKLSymbolicDivergence(learning_period_size=3, delta=0.0, gamma=1.0),
+        ),
+        (
+            "windowed_slope_kl_symbolic_divergence",
+            WindowedSlopeKLSymbolicDivergence(learning_period_size=3, recent_window_size=4, delta=0.0, gamma=1.0),
         ),
         (
             "univariate_gaussian_conjugate_bocpd",

--- a/tests/unit/algorithms/online/symbolic_divergence/abstracts/test_symbolic_divergence.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/abstracts/test_symbolic_divergence.py
@@ -1,0 +1,149 @@
+# -*- coding: ascii -*-
+"""
+Tests for symbolic divergence.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import pytest
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.kl_divergence import KLDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.slope_encoder import SlopeEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.scaled import ScaledDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.symbolic_divergence import (
+    SymbolicDivergence,
+    SymbolicDivergenceConfiguration,
+    SymbolicDivergenceState,
+)
+
+
+class _MinimalSymbolicDivergence(SymbolicDivergence[SymbolicDivergenceConfiguration, SymbolicDivergenceState]):
+    def __init__(self, learning_period_size: int = 3, statistic=None) -> None:
+        super().__init__(
+            configuration=SymbolicDivergenceConfiguration(learning_period_size=learning_period_size),
+            encoder=SlopeEncoder(delta=0.0, gamma=1.0),
+            divergence=KLDivergence(),
+            statistic=statistic,
+        )
+
+    @property
+    def name(self) -> str:
+        return "_MinimalSymbolicDivergence"
+
+    @property
+    def configuration(self) -> SymbolicDivergenceConfiguration:
+        return self._configuration
+
+    @property
+    def state(self) -> SymbolicDivergenceState:
+        return SymbolicDivergenceState(
+            is_in_learning_period=self.is_in_learning_period,
+            samples_count=self.samples_count,
+            symbol_counts=self.symbol_counts,
+            reference_distribution=self.reference_distribution,
+        )
+
+
+class TestSymbolicDivergenceConfiguration:
+    def test_rejects_non_positive_learning_period_size(self) -> None:
+        with pytest.raises(ValueError, match="learning_period_size"):
+            SymbolicDivergenceConfiguration(learning_period_size=0)
+
+    def test_identical_configs_have_same_hash(self) -> None:
+        config_a = SymbolicDivergenceConfiguration(learning_period_size=10)
+        config_b = SymbolicDivergenceConfiguration(learning_period_size=10)
+        assert hash(config_a) == hash(config_b)
+        assert config_a == config_b
+
+    def test_different_configs_have_different_hash(self) -> None:
+        config_a = SymbolicDivergenceConfiguration(learning_period_size=5)
+        config_b = SymbolicDivergenceConfiguration(learning_period_size=10)
+        assert hash(config_a) != hash(config_b)
+
+
+class TestSymbolicDivergenceState:
+    def test_empty_state_is_hashable(self) -> None:
+        state = SymbolicDivergenceState(is_in_learning_period=True)
+        assert isinstance(hash(state), int)
+
+    def test_identical_states_have_same_hash(self) -> None:
+        state_a = SymbolicDivergenceState(is_in_learning_period=False, samples_count=3, symbol_counts=(1, 2))
+        state_b = SymbolicDivergenceState(is_in_learning_period=False, samples_count=3, symbol_counts=(1, 2))
+        assert hash(state_a) == hash(state_b)
+
+
+class TestSymbolicDivergenceConstruction:
+    def test_cannot_instantiate_abstract_base(self) -> None:
+        with pytest.raises(TypeError):
+            SymbolicDivergence(  # type: ignore[abstract]
+                configuration=SymbolicDivergenceConfiguration(learning_period_size=3),
+                encoder=SlopeEncoder(delta=0.0, gamma=1.0),
+                divergence=KLDivergence(),
+            )
+
+    def test_rejects_learning_period_not_greater_than_window(self) -> None:
+        with pytest.raises(ValueError, match="must be strictly"):
+            _MinimalSymbolicDivergence(learning_period_size=2)
+
+    def test_defaults_to_raw_statistic(self) -> None:
+        algorithm = _MinimalSymbolicDivergence()
+        assert isinstance(algorithm.statistic, RawDivergenceStatistic)
+
+    def test_injected_components_are_exposed(self) -> None:
+        algorithm = _MinimalSymbolicDivergence(statistic=ScaledDivergenceStatistic())
+        assert isinstance(algorithm.encoder, SlopeEncoder)
+        assert isinstance(algorithm.divergence, KLDivergence)
+        assert isinstance(algorithm.statistic, ScaledDivergenceStatistic)
+
+
+class TestSymbolicDivergenceProcess:
+    def test_learning_period_emits_zero_then_scores(self) -> None:
+        algorithm = _MinimalSymbolicDivergence(learning_period_size=3)
+        emitted = [algorithm.process(value) for value in [0.0, 2.0, 4.0, 6.0, 0.0]]
+        assert emitted[0] == 0.0
+        assert emitted[1] == 0.0
+        assert emitted[2] == 0.0
+        assert all(isinstance(value, float) for value in emitted)
+
+    def test_reference_distribution_set_after_learning(self) -> None:
+        algorithm = _MinimalSymbolicDivergence(learning_period_size=3)
+        for value in [0.0, 2.0, 4.0]:
+            algorithm.process(value)
+        assert algorithm.reference_distribution != ()
+        assert len(algorithm.reference_distribution) == algorithm.encoder.num_symbols
+
+    def test_symbol_counts_accumulate(self) -> None:
+        algorithm = _MinimalSymbolicDivergence(learning_period_size=3)
+        for value in [0.0, 2.0, 4.0]:
+            algorithm.process(value)
+        assert sum(algorithm.symbol_counts) == 2
+
+
+class TestSymbolicDivergenceReset:
+    def test_reset_restores_fresh_state(self) -> None:
+        algorithm = _MinimalSymbolicDivergence(learning_period_size=3)
+        for value in [0.0, 2.0, 4.0, 6.0]:
+            algorithm.process(value)
+        algorithm.reset()
+        assert algorithm.samples_count == 0
+        assert algorithm.is_in_learning_period is True
+        assert algorithm.reference_distribution == ()
+        assert sum(algorithm.symbol_counts) == 0
+
+
+class TestSymbolicDivergenceRecreate:
+    def test_recreate_returns_independent_fresh_instance(self) -> None:
+        algorithm = _MinimalSymbolicDivergence(learning_period_size=3)
+        for value in [0.0, 2.0, 4.0, 6.0]:
+            algorithm.process(value)
+
+        recreated = algorithm.recreate()
+
+        assert recreated is not algorithm
+        assert recreated.samples_count == 0
+        assert recreated.is_in_learning_period is True

--- a/tests/unit/algorithms/online/symbolic_divergence/abstracts/test_windowed_symbolic_divergence.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/abstracts/test_windowed_symbolic_divergence.py
@@ -144,6 +144,23 @@ class TestWindowedSymbolicDivergenceProcess:
         assert any(value != 0.0 for value in emitted)
         assert all(math.isfinite(float(value)) for value in emitted)
 
+    def test_emits_zero_until_recent_window_fills(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=4)
+        emitted = [algorithm.process(value) for value in [0.0, 2.0, 4.0, 5.0, 4.0, 8.0, 7.0]]
+        assert emitted[:6] == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        assert emitted[6] != 0.0
+
+    def test_reference_distribution_updates_when_window_slides(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=4)
+        for value in [0.0, 2.0, 4.0, 5.0, 4.0, 8.0, 7.0]:
+            algorithm.process(value)
+
+        reference_before = algorithm.reference_distribution
+        assert reference_before != ()
+
+        algorithm.process(9.0)
+        assert algorithm.reference_distribution != reference_before
+
     def test_recent_window_counts_are_bounded(self) -> None:
         algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
         for value in [0.0, 2.0, 4.0, 6.0, 0.0, 5.0, -5.0, 2.0, 7.0, -1.0]:
@@ -162,6 +179,17 @@ class TestWindowedSymbolicDivergenceReset:
         assert algorithm.is_in_learning_period is True
         assert algorithm.reference_distribution == ()
         assert sum(algorithm.symbol_counts) == 0
+
+    def test_reset_resets_statistic_component(self) -> None:
+        statistic = LogScaledDivergenceStatistic()
+        statistic.update(1.0, 1)
+        algorithm = _MinimalWindowedSymbolicDivergence(
+            learning_period_size=3, recent_window_size=4, statistic=statistic
+        )
+        assert statistic.value != 0.0
+
+        algorithm.reset()
+        assert statistic.value == 0.0
 
 
 class TestWindowedSymbolicDivergenceRecreate:

--- a/tests/unit/algorithms/online/symbolic_divergence/abstracts/test_windowed_symbolic_divergence.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/abstracts/test_windowed_symbolic_divergence.py
@@ -1,0 +1,177 @@
+# -*- coding: ascii -*-
+"""
+Tests for windowed symbolic divergence.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import math
+
+import pytest
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.kl_divergence import KLDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.slope_encoder import SlopeEncoder
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.log_scaled import LogScaledDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.windowed_symbolic_divergence import (
+    WindowedSymbolicDivergence,
+    WindowedSymbolicDivergenceConfiguration,
+    WindowedSymbolicDivergenceState,
+)
+
+
+class _MinimalWindowedSymbolicDivergence(
+    WindowedSymbolicDivergence[WindowedSymbolicDivergenceConfiguration, WindowedSymbolicDivergenceState]
+):
+    def __init__(self, learning_period_size: int = 3, recent_window_size: int = 3, statistic=None) -> None:
+        super().__init__(
+            configuration=WindowedSymbolicDivergenceConfiguration(
+                learning_period_size=learning_period_size,
+                recent_window_size=recent_window_size,
+            ),
+            encoder=SlopeEncoder(delta=0.0, gamma=1.0),
+            divergence=KLDivergence(),
+            statistic=statistic,
+        )
+
+    @property
+    def name(self) -> str:
+        return "_MinimalWindowedSymbolicDivergence"
+
+    @property
+    def configuration(self) -> WindowedSymbolicDivergenceConfiguration:
+        return self._configuration
+
+    @property
+    def state(self) -> WindowedSymbolicDivergenceState:
+        return WindowedSymbolicDivergenceState(
+            is_in_learning_period=self.is_in_learning_period,
+            samples_count=self.samples_count,
+            symbol_counts=self.symbol_counts,
+            reference_distribution=self.reference_distribution,
+        )
+
+
+class TestWindowedSymbolicDivergenceConfiguration:
+    def test_rejects_non_positive_learning_period_size(self) -> None:
+        with pytest.raises(ValueError, match="learning_period_size"):
+            WindowedSymbolicDivergenceConfiguration(learning_period_size=0, recent_window_size=3)
+
+    def test_rejects_non_positive_recent_window_size(self) -> None:
+        with pytest.raises(ValueError, match="recent_window_size"):
+            WindowedSymbolicDivergenceConfiguration(learning_period_size=3, recent_window_size=0)
+
+    def test_identical_configs_have_same_hash(self) -> None:
+        config_a = WindowedSymbolicDivergenceConfiguration(learning_period_size=10, recent_window_size=8)
+        config_b = WindowedSymbolicDivergenceConfiguration(learning_period_size=10, recent_window_size=8)
+        assert hash(config_a) == hash(config_b)
+        assert config_a == config_b
+
+    @pytest.mark.parametrize("overrides", [{"learning_period_size": 5}, {"recent_window_size": 4}])
+    def test_different_configs_have_different_hash(self, overrides: dict) -> None:
+        base = {"learning_period_size": 10, "recent_window_size": 8}
+        config_a = WindowedSymbolicDivergenceConfiguration(**base)
+        config_b = WindowedSymbolicDivergenceConfiguration(**{**base, **overrides})
+        assert hash(config_a) != hash(config_b)
+
+
+class TestWindowedSymbolicDivergenceState:
+    def test_empty_state_is_hashable(self) -> None:
+        state = WindowedSymbolicDivergenceState(is_in_learning_period=True)
+        assert isinstance(hash(state), int)
+
+    def test_identical_states_have_same_hash(self) -> None:
+        state_a = WindowedSymbolicDivergenceState(is_in_learning_period=False, samples_count=3, symbol_counts=(1, 2))
+        state_b = WindowedSymbolicDivergenceState(is_in_learning_period=False, samples_count=3, symbol_counts=(1, 2))
+        assert hash(state_a) == hash(state_b)
+
+
+class TestWindowedSymbolicDivergenceConstruction:
+    def test_cannot_instantiate_abstract_base(self) -> None:
+        with pytest.raises(TypeError):
+            WindowedSymbolicDivergence(  # type: ignore[abstract]
+                configuration=WindowedSymbolicDivergenceConfiguration(learning_period_size=3, recent_window_size=3),
+                encoder=SlopeEncoder(delta=0.0, gamma=1.0),
+                divergence=KLDivergence(),
+            )
+
+    def test_rejects_learning_period_not_greater_than_window(self) -> None:
+        with pytest.raises(ValueError, match="must be strictly"):
+            _MinimalWindowedSymbolicDivergence(learning_period_size=2, recent_window_size=4)
+
+    def test_rejects_recent_window_not_greater_than_window(self) -> None:
+        with pytest.raises(ValueError, match="must be strictly"):
+            _MinimalWindowedSymbolicDivergence(learning_period_size=4, recent_window_size=2)
+
+    def test_defaults_to_raw_statistic(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence()
+        assert isinstance(algorithm.statistic, RawDivergenceStatistic)
+
+    def test_injected_components_are_exposed(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(statistic=LogScaledDivergenceStatistic())
+        assert isinstance(algorithm.encoder, SlopeEncoder)
+        assert isinstance(algorithm.divergence, KLDivergence)
+        assert isinstance(algorithm.statistic, LogScaledDivergenceStatistic)
+
+
+class TestWindowedSymbolicDivergenceProcess:
+    def test_learning_period_emits_zero(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        emitted = [algorithm.process(value) for value in [0.0, 2.0, 4.0]]
+        assert emitted == [0.0, 0.0, 0.0]
+        assert all(isinstance(value, float) for value in emitted)
+
+    def test_reference_distribution_set_after_learning(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        for value in [0.0, 2.0, 4.0]:
+            algorithm.process(value)
+        assert algorithm.reference_distribution != ()
+        assert len(algorithm.reference_distribution) == algorithm.encoder.num_symbols
+
+    def test_symbol_counts_reset_when_reference_is_fixed(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        for value in [0.0, 2.0, 4.0]:
+            algorithm.process(value)
+        assert sum(algorithm.symbol_counts) == 0
+
+    def test_emits_finite_scores_after_recent_window_fills(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        emitted = [algorithm.process(value) for value in [0.0, 2.0, 4.0, 6.0, 0.0, 5.0, -5.0, 2.0]]
+        assert any(value != 0.0 for value in emitted)
+        assert all(math.isfinite(float(value)) for value in emitted)
+
+    def test_recent_window_counts_are_bounded(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        for value in [0.0, 2.0, 4.0, 6.0, 0.0, 5.0, -5.0, 2.0, 7.0, -1.0]:
+            algorithm.process(value)
+        maxlen = 3 - 2 + 1
+        assert sum(algorithm.symbol_counts) == maxlen
+
+
+class TestWindowedSymbolicDivergenceReset:
+    def test_reset_restores_fresh_state(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        for value in [0.0, 2.0, 4.0, 6.0, 0.0, 5.0]:
+            algorithm.process(value)
+        algorithm.reset()
+        assert algorithm.samples_count == 0
+        assert algorithm.is_in_learning_period is True
+        assert algorithm.reference_distribution == ()
+        assert sum(algorithm.symbol_counts) == 0
+
+
+class TestWindowedSymbolicDivergenceRecreate:
+    def test_recreate_returns_independent_fresh_instance(self) -> None:
+        algorithm = _MinimalWindowedSymbolicDivergence(learning_period_size=3, recent_window_size=3)
+        for value in [0.0, 2.0, 4.0, 6.0, 0.0, 5.0]:
+            algorithm.process(value)
+
+        recreated = algorithm.recreate()
+
+        assert recreated is not algorithm
+        assert recreated.samples_count == 0
+        assert recreated.is_in_learning_period is True

--- a/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_slope_kl_symbolic_divergence.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_slope_kl_symbolic_divergence.py
@@ -1,0 +1,98 @@
+# -*- coding: ascii -*-
+"""
+Tests for slope kl symbolic divergence.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import math
+
+import pytest
+
+from pysatl_cpd.algorithms.online import SlopeKLSymbolicDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.slope_kl_symbolic_divergence import (
+    SlopeKLSymbolicDivergenceConfiguration,
+    SlopeKLSymbolicDivergenceState,
+)
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.scaled import ScaledDivergenceStatistic
+
+
+class TestSlopeKLSymbolicDivergenceConfiguration:
+    def test_rejects_non_positive_learning_period_size(self) -> None:
+        with pytest.raises(ValueError, match="learning_period_size"):
+            SlopeKLSymbolicDivergenceConfiguration(learning_period_size=0, delta=0.0, gamma=1.0)
+
+    def test_identical_configs_have_same_hash(self) -> None:
+        config_a = SlopeKLSymbolicDivergenceConfiguration(learning_period_size=10, delta=0.1, gamma=1.0, smoothing=1e-9)
+        config_b = SlopeKLSymbolicDivergenceConfiguration(learning_period_size=10, delta=0.1, gamma=1.0, smoothing=1e-9)
+        assert hash(config_a) == hash(config_b)
+        assert config_a == config_b
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"delta": 0.2},
+            {"gamma": 2.0},
+            {"smoothing": 1e-6},
+            {"learning_period_size": 20},
+        ],
+    )
+    def test_different_component_params_have_different_hash(self, overrides: dict) -> None:
+        base = {"learning_period_size": 10, "delta": 0.1, "gamma": 1.0, "smoothing": 1e-9}
+        config_a = SlopeKLSymbolicDivergenceConfiguration(**base)
+        config_b = SlopeKLSymbolicDivergenceConfiguration(**{**base, **overrides})
+        assert hash(config_a) != hash(config_b)
+
+
+class TestSlopeKLSymbolicDivergenceConstruction:
+    def test_rejects_learning_period_not_greater_than_window(self) -> None:
+        with pytest.raises(ValueError, match="must be strictly"):
+            SlopeKLSymbolicDivergence(learning_period_size=2, delta=0.0, gamma=1.0)
+
+    def test_delegates_encoder_validation(self) -> None:
+        with pytest.raises(ValueError, match="gamma"):
+            SlopeKLSymbolicDivergence(learning_period_size=5, delta=1.0, gamma=1.0)
+
+    def test_defaults_to_scaled_two_n_d_statistic(self) -> None:
+        algorithm = SlopeKLSymbolicDivergence(learning_period_size=5, delta=0.0, gamma=1.0)
+        assert isinstance(algorithm.statistic, ScaledDivergenceStatistic)
+
+    def test_explicit_statistic_is_respected(self) -> None:
+        statistic = RawDivergenceStatistic()
+        algorithm = SlopeKLSymbolicDivergence(learning_period_size=5, delta=0.0, gamma=1.0, statistic=statistic)
+        assert algorithm.statistic is statistic
+
+
+class TestSlopeKLSymbolicDivergence:
+    def test_name_and_types(self) -> None:
+        algorithm = SlopeKLSymbolicDivergence(learning_period_size=5, delta=0.0, gamma=1.0)
+        assert algorithm.name == "SlopeKLSymbolicDivergence"
+        assert isinstance(algorithm.configuration, SlopeKLSymbolicDivergenceConfiguration)
+        assert isinstance(algorithm.state, SlopeKLSymbolicDivergenceState)
+
+    def test_learning_period_emits_zero_then_finite_scores(self) -> None:
+        algorithm = SlopeKLSymbolicDivergence(learning_period_size=4, delta=0.0, gamma=1.0)
+        emitted = [algorithm.process(value) for value in [0.0, 1.0, 2.0, 3.0, 10.0, -10.0]]
+        assert emitted[:4] == [0.0, 0.0, 0.0, 0.0]
+        assert all(math.isfinite(float(value)) for value in emitted)
+
+    def test_default_value_equals_two_n_times_raw_divergence(self) -> None:
+        observations = [0.0, 1.0, 2.0, 3.0, 4.0, 10.0, -5.0, 8.0]
+        scaled = SlopeKLSymbolicDivergence(learning_period_size=4, delta=0.0, gamma=1.0)
+        raw = SlopeKLSymbolicDivergence(
+            learning_period_size=4, delta=0.0, gamma=1.0, statistic=RawDivergenceStatistic()
+        )
+
+        scaled_value = 0.0
+        raw_value = 0.0
+        for observation in observations:
+            scaled_value = float(scaled.process(observation))
+            raw_value = float(raw.process(observation))
+
+        sample_size = sum(scaled.symbol_counts)
+        assert scaled_value == pytest.approx(2.0 * sample_size * raw_value)

--- a/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_slope_kl_symbolic_divergence_contract.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_slope_kl_symbolic_divergence_contract.py
@@ -1,0 +1,31 @@
+# -*- coding: ascii -*-
+"""
+Tests for slope kl symbolic divergence contract.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import pytest
+
+from pysatl_cpd.algorithms.online import SlopeKLSymbolicDivergence
+from tests.contracts.core.test_online_algorithm_contract import OnlineAlgorithmContract
+
+
+class TestSlopeKLSymbolicDivergenceContract(OnlineAlgorithmContract):
+    @pytest.fixture
+    def algorithm(self) -> SlopeKLSymbolicDivergence:
+        return SlopeKLSymbolicDivergence(learning_period_size=4, delta=0.0, gamma=1.0)
+
+    @pytest.fixture
+    def sample_observation(self) -> float:
+        return 1.0
+
+    @pytest.fixture
+    def update_observations(self) -> list[float]:
+        return [0.0, 1.0, 2.0, 3.0, 10.0, -5.0]
+
+    @pytest.fixture
+    def fresh_state(self):
+        return SlopeKLSymbolicDivergence(learning_period_size=4, delta=0.0, gamma=1.0).state

--- a/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_windowed_slope_kl_symbolic_divergence.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_windowed_slope_kl_symbolic_divergence.py
@@ -1,0 +1,126 @@
+# -*- coding: ascii -*-
+"""
+Tests for windowed slope kl symbolic divergence.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import math
+
+import pytest
+
+from pysatl_cpd.algorithms.online import WindowedSlopeKLSymbolicDivergence
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.log_scaled import LogScaledDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+from pysatl_cpd.algorithms.online.symbolic_divergence.windowed_slope_kl_symbolic_divergence import (
+    WindowedSlopeKLSymbolicDivergenceConfiguration,
+    WindowedSlopeKLSymbolicDivergenceState,
+)
+
+
+class TestWindowedSlopeKLSymbolicDivergenceConfiguration:
+    def test_rejects_non_positive_learning_period_size(self) -> None:
+        with pytest.raises(ValueError, match="learning_period_size"):
+            WindowedSlopeKLSymbolicDivergenceConfiguration(
+                learning_period_size=0, recent_window_size=4, delta=0.0, gamma=1.0
+            )
+
+    def test_rejects_non_positive_recent_window_size(self) -> None:
+        with pytest.raises(ValueError, match="recent_window_size"):
+            WindowedSlopeKLSymbolicDivergenceConfiguration(
+                learning_period_size=4, recent_window_size=0, delta=0.0, gamma=1.0
+            )
+
+    def test_identical_configs_have_same_hash(self) -> None:
+        config_a = WindowedSlopeKLSymbolicDivergenceConfiguration(
+            learning_period_size=10, recent_window_size=8, delta=0.1, gamma=1.0, smoothing=1e-9
+        )
+        config_b = WindowedSlopeKLSymbolicDivergenceConfiguration(
+            learning_period_size=10, recent_window_size=8, delta=0.1, gamma=1.0, smoothing=1e-9
+        )
+        assert hash(config_a) == hash(config_b)
+        assert config_a == config_b
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"delta": 0.2},
+            {"gamma": 2.0},
+            {"smoothing": 1e-6},
+            {"learning_period_size": 20},
+            {"recent_window_size": 12},
+        ],
+    )
+    def test_different_component_params_have_different_hash(self, overrides: dict) -> None:
+        base = {"learning_period_size": 10, "recent_window_size": 8, "delta": 0.1, "gamma": 1.0, "smoothing": 1e-9}
+        config_a = WindowedSlopeKLSymbolicDivergenceConfiguration(**base)
+        config_b = WindowedSlopeKLSymbolicDivergenceConfiguration(**{**base, **overrides})
+        assert hash(config_a) != hash(config_b)
+
+
+class TestWindowedSlopeKLSymbolicDivergenceConstruction:
+    def test_rejects_learning_period_not_greater_than_window(self) -> None:
+        with pytest.raises(ValueError, match="must be strictly"):
+            WindowedSlopeKLSymbolicDivergence(learning_period_size=2, recent_window_size=4, delta=0.0, gamma=1.0)
+
+    def test_rejects_recent_window_not_greater_than_window(self) -> None:
+        with pytest.raises(ValueError, match="must be strictly"):
+            WindowedSlopeKLSymbolicDivergence(learning_period_size=4, recent_window_size=2, delta=0.0, gamma=1.0)
+
+    def test_delegates_encoder_validation(self) -> None:
+        with pytest.raises(ValueError, match="gamma"):
+            WindowedSlopeKLSymbolicDivergence(learning_period_size=5, recent_window_size=5, delta=1.0, gamma=1.0)
+
+    def test_defaults_to_raw_statistic(self) -> None:
+        algorithm = WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=5, recent_window_size=5, delta=0.0, gamma=1.0
+        )
+        assert isinstance(algorithm.statistic, RawDivergenceStatistic)
+
+    def test_explicit_statistic_is_respected(self) -> None:
+        statistic = LogScaledDivergenceStatistic()
+        algorithm = WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=5, recent_window_size=5, delta=0.0, gamma=1.0, statistic=statistic
+        )
+        assert algorithm.statistic is statistic
+
+
+class TestWindowedSlopeKLSymbolicDivergence:
+    def test_name_and_types(self) -> None:
+        algorithm = WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=5, recent_window_size=5, delta=0.0, gamma=1.0
+        )
+        assert algorithm.name == "WindowedSlopeKLSymbolicDivergence"
+        assert isinstance(algorithm.configuration, WindowedSlopeKLSymbolicDivergenceConfiguration)
+        assert isinstance(algorithm.state, WindowedSlopeKLSymbolicDivergenceState)
+
+    def test_learning_period_emits_zero_then_finite_scores(self) -> None:
+        algorithm = WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=4, recent_window_size=4, delta=0.0, gamma=1.0
+        )
+        emitted = [algorithm.process(value) for value in [0.0, 1.0, 2.0, 3.0, 10.0, -10.0, 5.0, -2.0, 7.0, 1.0]]
+        assert emitted[:4] == [0.0, 0.0, 0.0, 0.0]
+        assert all(math.isfinite(float(value)) for value in emitted)
+
+    def test_recent_window_counts_are_bounded(self) -> None:
+        algorithm = WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=4, recent_window_size=4, delta=0.0, gamma=1.0
+        )
+        for value in [0.0, 1.0, 2.0, 3.0, 10.0, -10.0, 5.0, -2.0, 7.0, 1.0, 3.0, 9.0]:
+            algorithm.process(value)
+        maxlen = 4 - 2 + 1
+        assert sum(algorithm.symbol_counts) == maxlen
+
+    def test_state_reference_distribution_after_learning(self) -> None:
+        algorithm = WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=4, recent_window_size=4, delta=0.0, gamma=1.0
+        )
+        for value in [0.0, 1.0, 2.0, 3.0]:
+            algorithm.process(value)
+        state = algorithm.state
+        assert state.reference_distribution != ()
+        assert len(state.reference_distribution) == algorithm.encoder.num_symbols

--- a/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_windowed_slope_kl_symbolic_divergence_contract.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/algorithm/test_windowed_slope_kl_symbolic_divergence_contract.py
@@ -1,0 +1,33 @@
+# -*- coding: ascii -*-
+"""
+Tests for windowed slope kl symbolic divergence contract.
+"""
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import pytest
+
+from pysatl_cpd.algorithms.online import WindowedSlopeKLSymbolicDivergence
+from tests.contracts.core.test_online_algorithm_contract import OnlineAlgorithmContract
+
+
+class TestWindowedSlopeKLSymbolicDivergenceContract(OnlineAlgorithmContract):
+    @pytest.fixture
+    def algorithm(self) -> WindowedSlopeKLSymbolicDivergence:
+        return WindowedSlopeKLSymbolicDivergence(learning_period_size=4, recent_window_size=4, delta=0.0, gamma=1.0)
+
+    @pytest.fixture
+    def sample_observation(self) -> float:
+        return 1.0
+
+    @pytest.fixture
+    def update_observations(self) -> list[float]:
+        return [0.0, 1.0, 2.0, 3.0, 10.0, -5.0, 8.0, 1.0]
+
+    @pytest.fixture
+    def fresh_state(self):
+        return WindowedSlopeKLSymbolicDivergence(
+            learning_period_size=4, recent_window_size=4, delta=0.0, gamma=1.0
+        ).state

--- a/tests/unit/algorithms/online/symbolic_divergence/component/divergences/test_kl_divergence.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/component/divergences/test_kl_divergence.py
@@ -1,0 +1,62 @@
+# -*- coding: ascii -*-
+"""
+Tests for kl divergence.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import numpy as np
+import pytest
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.divergences.kl_divergence import KLDivergence
+
+
+class TestKLDivergenceConstruction:
+    def test_rejects_negative_smoothing(self) -> None:
+        with pytest.raises(ValueError, match="smoothing must be non-negative"):
+            KLDivergence(smoothing=-1e-3)
+
+
+class TestKLDivergenceCompute:
+    def test_identical_distributions_have_zero_divergence(self) -> None:
+        divergence = KLDivergence()
+        reference = np.array([1.0, 2.0, 3.0, 4.0])
+        assert divergence.compute(reference, reference) == pytest.approx(0.0, abs=1e-6)
+
+    def test_different_distributions_have_positive_divergence(self) -> None:
+        divergence = KLDivergence()
+        empirical = np.array([10.0, 1.0, 1.0])
+        reference = np.array([1.0, 1.0, 10.0])
+        assert divergence.compute(empirical, reference) > 0.0
+
+    def test_counts_and_probabilities_give_same_result(self) -> None:
+        divergence = KLDivergence(smoothing=0.0)
+        counts_empirical = np.array([2.0, 6.0, 2.0])
+        counts_reference = np.array([5.0, 5.0, 10.0])
+        prob_empirical = counts_empirical / counts_empirical.sum()
+        prob_reference = counts_reference / counts_reference.sum()
+        assert divergence.compute(counts_empirical, counts_reference) == pytest.approx(
+            divergence.compute(prob_empirical, prob_reference)
+        )
+
+    def test_zero_empirical_entries_are_skipped(self) -> None:
+        divergence = KLDivergence()
+        empirical = np.array([0.0, 1.0, 0.0])
+        reference = np.array([1.0, 1.0, 1.0])
+        assert np.isfinite(divergence.compute(empirical, reference))
+
+    def test_all_zero_empirical_returns_zero(self) -> None:
+        divergence = KLDivergence()
+        empirical = np.array([0.0, 0.0, 0.0])
+        reference = np.array([1.0, 1.0, 1.0])
+        assert divergence.compute(empirical, reference) == 0.0
+
+    def test_zero_reference_does_not_raise_with_smoothing(self) -> None:
+        divergence = KLDivergence(smoothing=1e-9)
+        empirical = np.array([1.0, 1.0])
+        reference = np.array([1.0, 0.0])
+        assert np.isfinite(divergence.compute(empirical, reference))

--- a/tests/unit/algorithms/online/symbolic_divergence/component/encoders/test_slope_encoder.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/component/encoders/test_slope_encoder.py
@@ -1,0 +1,79 @@
+# -*- coding: ascii -*-
+"""
+Tests for slope encoder.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import pytest
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.encoders.slope_encoder import SlopeEncoder
+
+
+class TestSlopeEncoderConstruction:
+    def test_rejects_negative_delta(self) -> None:
+        with pytest.raises(ValueError, match="delta must be non-negative"):
+            SlopeEncoder(delta=-0.1, gamma=1.0)
+
+    def test_rejects_non_positive_gamma(self) -> None:
+        with pytest.raises(ValueError, match="gamma must be positive"):
+            SlopeEncoder(delta=0.0, gamma=0.0)
+
+    def test_rejects_gamma_not_greater_than_delta(self) -> None:
+        with pytest.raises(ValueError, match="strictly greater than delta"):
+            SlopeEncoder(delta=1.0, gamma=1.0)
+
+
+class TestSlopeEncoderProperties:
+    def test_window_size_is_two(self) -> None:
+        assert SlopeEncoder(delta=0.0, gamma=1.0).window_size == 2
+
+    def test_num_symbols_is_five(self) -> None:
+        assert SlopeEncoder(delta=0.0, gamma=1.0).num_symbols == 5
+
+    def test_symbols_are_canonical_order(self) -> None:
+        assert SlopeEncoder(delta=0.0, gamma=1.0).symbols == (-2, -1, 0, 1, 2)
+
+
+class TestSlopeEncoderEncode:
+    @pytest.mark.parametrize(
+        ("window", "expected"),
+        [
+            ([0.0, -3.0], -2),
+            ([0.0, -1.5], -1),
+            ([0.0, 0.0], 0),
+            ([0.0, 1.5], 1),
+            ([0.0, 3.0], 2),
+        ],
+    )
+    def test_encode_maps_difference_to_symbol(self, window: list[float], expected: int) -> None:
+        encoder = SlopeEncoder(delta=0.5, gamma=2.0)
+        assert encoder.encode(window) == expected
+
+    def test_encode_uses_last_two_observations(self) -> None:
+        encoder = SlopeEncoder(delta=0.0, gamma=1.0)
+        assert encoder.encode([100.0, 0.0, 0.5]) == 1
+
+    def test_encode_boundary_delta_is_flat(self) -> None:
+        encoder = SlopeEncoder(delta=0.5, gamma=2.0)
+        assert encoder.encode([0.0, 0.5]) == 0
+
+    def test_encode_boundary_gamma_is_steep(self) -> None:
+        encoder = SlopeEncoder(delta=0.5, gamma=2.0)
+        assert encoder.encode([0.0, 2.0]) == 1
+
+    def test_encode_rejects_short_window(self) -> None:
+        encoder = SlopeEncoder(delta=0.0, gamma=1.0)
+        with pytest.raises(ValueError, match="at least 2 observations"):
+            encoder.encode([1.0])
+
+
+class TestSlopeEncoderReset:
+    def test_reset_is_noop(self) -> None:
+        encoder = SlopeEncoder(delta=0.0, gamma=1.0)
+        assert encoder.reset() is None
+        assert encoder.encode([0.0, 2.0]) == 2

--- a/tests/unit/algorithms/online/symbolic_divergence/component/statistics/test_log_scaled.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/component/statistics/test_log_scaled.py
@@ -1,0 +1,43 @@
+# -*- coding: ascii -*-
+"""
+Tests for log-scaled divergence statistic.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import math
+
+import pytest
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.log_scaled import LogScaledDivergenceStatistic
+
+
+class TestLogScaledDivergenceStatisticConstruction:
+    def test_rejects_negative_scale(self) -> None:
+        with pytest.raises(ValueError, match="scale must be non-negative"):
+            LogScaledDivergenceStatistic(scale=-1.0)
+
+
+class TestLogScaledDivergenceStatistic:
+    def test_initial_value_is_zero(self) -> None:
+        assert LogScaledDivergenceStatistic().value == 0.0
+
+    def test_default_scale_applies_logarithmic_damping(self) -> None:
+        statistic = LogScaledDivergenceStatistic()
+        statistic.update(0.5, sample_size=8)
+        assert statistic.value == pytest.approx(2.0 * (8 / math.log(9)) * 0.5)
+
+    def test_custom_scale_is_applied(self) -> None:
+        statistic = LogScaledDivergenceStatistic(scale=3.0)
+        statistic.update(0.25, sample_size=4)
+        assert statistic.value == pytest.approx(3.0 * (4 / math.log(5)) * 0.25)
+
+    def test_reset_clears_value(self) -> None:
+        statistic = LogScaledDivergenceStatistic()
+        statistic.update(0.5, sample_size=8)
+        statistic.reset()
+        assert statistic.value == 0.0

--- a/tests/unit/algorithms/online/symbolic_divergence/component/statistics/test_raw.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/component/statistics/test_raw.py
@@ -1,0 +1,35 @@
+# -*- coding: ascii -*-
+"""
+Tests for raw divergence statistic.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.raw import RawDivergenceStatistic
+
+
+class TestRawDivergenceStatistic:
+    def test_initial_value_is_zero(self) -> None:
+        assert RawDivergenceStatistic().value == 0.0
+
+    def test_update_stores_latest_divergence(self) -> None:
+        statistic = RawDivergenceStatistic()
+        statistic.update(0.7, sample_size=10)
+        assert statistic.value == 0.7
+
+    def test_sample_size_is_ignored(self) -> None:
+        statistic = RawDivergenceStatistic()
+        statistic.update(0.4, sample_size=1)
+        first = statistic.value
+        statistic.update(0.4, sample_size=1000)
+        assert statistic.value == first
+
+    def test_reset_clears_value(self) -> None:
+        statistic = RawDivergenceStatistic()
+        statistic.update(0.9, sample_size=5)
+        statistic.reset()
+        assert statistic.value == 0.0

--- a/tests/unit/algorithms/online/symbolic_divergence/component/statistics/test_scaled.py
+++ b/tests/unit/algorithms/online/symbolic_divergence/component/statistics/test_scaled.py
@@ -1,0 +1,41 @@
+# -*- coding: ascii -*-
+"""
+Tests for scaled divergence statistic.
+"""
+
+from __future__ import annotations
+
+__author__ = "Yulia Burmistrova"
+__copyright__ = "Copyright (c) 2026 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+import pytest
+
+from pysatl_cpd.algorithms.online.symbolic_divergence.statistics.scaled import ScaledDivergenceStatistic
+
+
+class TestScaledDivergenceStatisticConstruction:
+    def test_rejects_negative_scale(self) -> None:
+        with pytest.raises(ValueError, match="scale must be non-negative"):
+            ScaledDivergenceStatistic(scale=-1.0)
+
+
+class TestScaledDivergenceStatistic:
+    def test_initial_value_is_zero(self) -> None:
+        assert ScaledDivergenceStatistic().value == 0.0
+
+    def test_default_scale_produces_two_n_d(self) -> None:
+        statistic = ScaledDivergenceStatistic()
+        statistic.update(0.5, sample_size=8)
+        assert statistic.value == pytest.approx(2.0 * 8 * 0.5)
+
+    def test_custom_scale_is_applied(self) -> None:
+        statistic = ScaledDivergenceStatistic(scale=3.0)
+        statistic.update(0.25, sample_size=4)
+        assert statistic.value == pytest.approx(3.0 * 4 * 0.25)
+
+    def test_reset_clears_value(self) -> None:
+        statistic = ScaledDivergenceStatistic()
+        statistic.update(0.5, sample_size=8)
+        statistic.reset()
+        assert statistic.value == 0.0


### PR DESCRIPTION
Adds SymbolicDivergence and WindowSymbolicDivergence, a generalized online change-point detection algorithm to pysatl_cpd.algorithms.online. It encodes a sliding window of observations into a symbol, monitors the divergence between the running empirical symbol distribution and a reference distribution fixed at the end of the learning period, and maps that divergence stream to a change-point statistic.

The algorithm is built from three interchangeable, pluggable components, making the Slope-encoding + Kullback-Leibler + 2nD combination a single special case of a broader family:

•  Encoder (ISymbolEncoder): h: R^k -> S, window-to-symbol mapping. SlopeEncoder is the canonical k = 2 case.
•  Divergence (IDivergence): compares the empirical symbol distribution to the reference. KLDivergence (with smoothing) is provided.
•  Change-point statistic (IChangePointStatistic): turns the raw divergence stream (and symbol count n) into the emitted statistic. RawDivergenceStatistic (identity, default) and ScaledDivergenceStatistic (scale * n * D; scale = 2.0 reproduces 2nD).