### PR TITLE
des/update checkout actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -59,7 +59,7 @@ jobs:
         run: poetry run coverage xml -o coverage.xml
 
       - name: Upload coverage.xml
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
           path: coverage.xml

--- a/pysatl_cpd/analysis/metrics/abstracts/isingle_run_metric.py
+++ b/pysatl_cpd/analysis/metrics/abstracts/isingle_run_metric.py
@@ -16,14 +16,10 @@ from pysatl_cpd.data.providers.labeled.labeled_data import LabeledData as Labele
 class ISingleRunMetric[TraceT: DetectionTrace, ProviderT: LabeledData, ResultT](ABC):
     """Base class for metrics that evaluate one run.
 
-    Type Parameters
-    ---------------
-    TraceT
-        Detection trace type.
-    ProviderT
-        Labeled data provider type.
-    ResultT
-        Metric result type.
+    Notes
+    -----
+    The generic parameters identify the detection trace type, labeled data
+    provider type, and metric result type.
     """
 
     @abstractmethod

--- a/pysatl_cpd/analysis/metrics/multiple_run/aggregation_metric.py
+++ b/pysatl_cpd/analysis/metrics/multiple_run/aggregation_metric.py
@@ -24,16 +24,10 @@ class AggregationMetric[TraceT: DetectionTrace, ProviderT: LabeledData[Any, Any]
 ):
     """Evaluate a single-run metric on each run and aggregate the results.
 
-    Type Parameters
-    ---------------
-    TraceT
-        Detection trace type.
-    ProviderT
-        Labeled data provider type.
-    ResultInT
-        Per-run metric result type.
-    ResultOutT
-        Aggregated result type.
+    Notes
+    -----
+    The generic parameters identify the detection trace type, labeled data
+    provider type, per-run metric result type, and aggregated result type.
     """
 
     @property

--- a/pysatl_cpd/analysis/metrics/multiple_run/derived_metric.py
+++ b/pysatl_cpd/analysis/metrics/multiple_run/derived_metric.py
@@ -21,16 +21,10 @@ class DerivedMetric[TraceT: DetectionTrace, ProviderT: LabeledData[Any, Any], Re
 ):
     """Evaluate several multi-run metrics and combine their outputs.
 
-    Type Parameters
-    ---------------
-    TraceT
-        Detection trace type.
-    ProviderT
-        Labeled data provider type.
-    ResultInT
-        Input metric result type.
-    ResultOutT
-        Derived metric result type.
+    Notes
+    -----
+    The generic parameters identify the detection trace type, labeled data
+    provider type, input metric result type, and derived metric result type.
     """
 
     @property

--- a/pysatl_cpd/analysis/visualization/abstracts/itimeseries_visualizer.py
+++ b/pysatl_cpd/analysis/visualization/abstracts/itimeseries_visualizer.py
@@ -27,16 +27,11 @@ class ITimeseriesVisualizer[DataProviderT: DataProvider[Any, TimeseriesAnnotatio
     optionally with ground truth change points, detected change points,
     and annotation of learning and skip periods.
 
-    Type Parameters
-    ---------------
-    DataProviderT : DataProvider
-        The data provider type bound by DataProvider, containing the
-        observations to be visualized.
-
     Notes
     -----
-    The type parameter DataProviderT is bound to DataProvider to ensure
-    that any concrete implementation works with valid data providers.
+    The generic DataProviderT type is bound by DataProvider and contains the
+    observations to be visualized. The bound ensures that any concrete
+    implementation works with valid data providers.
     """
 
     @abstractmethod

--- a/pysatl_cpd/analysis/visualization/abstracts/itrace_visualizer.py
+++ b/pysatl_cpd/analysis/visualization/abstracts/itrace_visualizer.py
@@ -25,19 +25,12 @@ class ITraceVisualizer[DetectionTraceT: DetectionTrace](IVisualizer, ABC):
     Visualizers of this type render detection results, including detection
     function values and algorithm metadata.
 
-    Type Parameters
-    ---------------
-    DetectionTraceT : DetectionTrace
-        The detection trace type bound by DetectionTrace. This allows
-        visualizers to work with specific trace implementations such as
-        OnlineDetectionTrace or OfflineDetectionTrace.
-
     Notes
     -----
-    The type parameter DetectionTraceT is bound to DetectionTrace to ensure
-    that any concrete implementation works with valid detection traces.
-    Due to mypy limitations with generic bounds, a type-ignore comment
-    is used on the TypeVar definition.
+    The generic DetectionTraceT type is bound by DetectionTrace. This allows
+    visualizers to work with specific trace implementations such as
+    OnlineDetectionTrace or OfflineDetectionTrace and ensures that any
+    concrete implementation works with valid detection traces.
     """
 
     @abstractmethod

--- a/pysatl_cpd/analysis/visualization/online/states/ionline_state_visualizer.py
+++ b/pysatl_cpd/analysis/visualization/online/states/ionline_state_visualizer.py
@@ -26,17 +26,12 @@ class IOnlineStateVisualizer[OnlineAlgorithmStateT: OnlineAlgorithmState](IVisua
     Visualizers of this type render the evolution of algorithm state
     over time, showing how internal statistics change with each observation.
 
-    Type Parameters
-    ---------------
-    OnlineAlgorithmStateT : OnlineAlgorithmState
-        The algorithm state type bound by OnlineAlgorithmState. This allows
-        visualizers to work with specific state implementations such as
-        ShewhartControlChartState.
-
     Notes
     -----
-    The type parameter is bound to OnlineAlgorithmState to ensure that
-    any concrete implementation works with valid algorithm state objects.
+    The generic OnlineAlgorithmStateT type is bound by OnlineAlgorithmState.
+    This allows visualizers to work with specific state implementations such
+    as ShewhartControlChartState and ensures that any concrete implementation
+    works with valid algorithm state objects.
     """
 
     @abstractmethod


### PR DESCRIPTION
- Update checkout actions due to the node.js 20 actions are deprecated (see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- Fix PyDocLint errors 
